### PR TITLE
Pluralizes the Conservation Records link in the navbar

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -6,7 +6,7 @@
           <%= link_to 'Treatment Database', root_path, class: 'navbar-brand' %>
         </li>
         <li class="nav-item">
-          <%= link_to('Conservation Record', conservation_records_path, class: 'nav-link') %>
+          <%= link_to('Conservation Records', conservation_records_path, class: 'nav-link') %>
         </li>
         <li class="nav-item">
           <%= link_to('Vocabularies', controlled_vocabularies_path, class: 'nav-link') %>

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'shared/_navigation.html.erb', type: :view do
+  include Devise::TestHelpers
+
+  before do
+    create(:user)
+    render
+  end
+
+  it 'has a menu with the expected links when signed out' do
+    expect(rendered).to have_link('Conservation Records')
+    expect(rendered).to have_link('Vocabularies')
+    expect(rendered).to have_link('Log in')
+    expect(rendered).to have_link('Sign up')
+  end
+end


### PR DESCRIPTION
The link to the Conservation Records page in the nav bar should be plural.

fixes: #28 