### PR TITLE
#33 Remove height declaration causing the squash.

### DIFF
--- a/app/views/conservation_records/conservation_worksheet.html.erb
+++ b/app/views/conservation_records/conservation_worksheet.html.erb
@@ -26,7 +26,6 @@ table {
 }
 
 .image img {
-  height: 100%; 
   width: 100%; 
   object-fit: contain;
 }


### PR DESCRIPTION
Fixes: #33 

I had set the container height for the image as 100%, for what ever reason that was causing the image to be somewhat squished on lucy