### PR TITLE
#14 Shows Database ID on Show and Index Page

### DIFF
--- a/app/views/conservation_records/index.html.erb
+++ b/app/views/conservation_records/index.html.erb
@@ -8,6 +8,7 @@
 <table class="table">
   <thead>
     <tr>
+      <th>Database ID</th>
       <th>Title</th>
       <th>Author</th>
       <th>Call number</th>
@@ -19,6 +20,7 @@
   <tbody>
     <% @conservation_records.each do |conservation_record| %>
       <tr>
+        <td><%= conservation_record.id %></td>
         <td><%= conservation_record.title %></td>
         <td><%= conservation_record.author %></td>
         <td><%= conservation_record.call_number %></td>

--- a/app/views/conservation_records/show.html.erb
+++ b/app/views/conservation_records/show.html.erb
@@ -17,6 +17,10 @@
     <table class="table table-striped">
       <tbody>
         <tr>
+          <th scope="row">Database ID</th>
+          <td><%= @conservation_record.id %></td>
+        </tr>
+        <tr>
           <th scope="row">Date Recieved</th>
           <td><%= @conservation_record.date_recieved_in_preservation_services.strftime("%m/%d/%Y") %></td>
         </tr>

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'conservation_records/index', type: :view do
   before(:each) do
     assign(:conservation_records, [
              ConservationRecord.create!(
+               id: 101,
                date_recieved_in_preservation_services: Date.new,
                department: 'Department',
                title: 'Title',
@@ -16,6 +17,7 @@ RSpec.describe 'conservation_records/index', type: :view do
                digitization: false
              ),
              ConservationRecord.create!(
+               id: 102,
                date_recieved_in_preservation_services: Date.new,
                department: 'Department',
                title: 'Title',
@@ -30,6 +32,8 @@ RSpec.describe 'conservation_records/index', type: :view do
 
   it 'renders a list of conservation_records' do
     render
+    assert_select 'td', text: '101', count: 1
+    assert_select 'td', text: '102', count: 1
     assert_select 'td', text: 'Title', count: 2
     assert_select 'td', text: 'Title', count: 2
     assert_select 'td', text: 'Author', count: 2

--- a/spec/views/conservation_records/show.html.erb_spec.rb
+++ b/spec/views/conservation_records/show.html.erb_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'conservation_records/show', type: :view do
 
   it 'shows the table with all metadata' do
     render
+    expect(rendered).to match(/Database ID/)
     expect(rendered).to match(/Date Recieved/)
     expect(rendered).to match(/Department/)
     expect(rendered).to match(/Title/)


### PR DESCRIPTION
Fixes: #14 

Adds a column on the index page for Database ID.

Adds Database ID to the Conservation Records show page.