### PR TITLE
#32 Fix Repair Records Forms

### DIFF
--- a/app/views/conservation_records/show.html.erb
+++ b/app/views/conservation_records/show.html.erb
@@ -120,20 +120,21 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
+      
+      <%= form_with(model: [@conservation_record, @conservation_record.in_house_repair_records.build]) do |form| %>
       <div class="modal-body">
-        <%= form_with(model: [@conservation_record, @conservation_record.in_house_repair_records.build], local:true) do |form| %>
-          <div class="form-group">
-            <label for="RepairedBy">Repaired By</label>
-              <%= form.select(:performed_by_user_id, options_from_collection_for_select(@users, "id", "display_name"), { prompt: 'Select User' }, { :class => 'form-control' }) %>
-          </div>
-          <div class="form-group">
-            <label>Repair Type</label>
-            <%= form.select :repair_type, options_from_collection_for_select(@repair_types, "id", "key"), { prompt: 'Select Repair Type' }, { :class => 'form-control' } %>
-          </div>
-          <div class="form-group">
-            <label>Minutes Spent</label>
-            <%= form.number_field :minutes_spent, class: "form-control", placeholder: "Minutes" %>
-          </div>
+        <div class="form-group">
+          <label for="RepairedBy">Repaired By</label>
+            <%= form.select(:performed_by_user_id, options_from_collection_for_select(@users, "id", "display_name"), { prompt: 'Select User' }, { :class => 'form-control' }) %>
+        </div>
+        <div class="form-group">
+          <label>Repair Type</label>
+          <%= form.select :repair_type, options_from_collection_for_select(@repair_types, "id", "key"), { prompt: 'Select Repair Type' }, { :class => 'form-control' } %>
+        </div>
+        <div class="form-group">
+          <label>Minutes Spent</label>
+          <%= form.number_field :minutes_spent, class: "form-control", placeholder: "Minutes" %>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
@@ -153,22 +154,23 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body">
-        <%= form_with(model: [@conservation_record, @conservation_record.external_repair_records.build], local:true) do |form| %>
+      
+      <%= form_with(model: [@conservation_record, @conservation_record.external_repair_records.build]) do |form| %>
+        <div class="modal-body">
           <div class="form-group">
             <label for="RepairedBy">Repaired By</label>
-              <%= form.select(:performed_by_vendor_id, options_from_collection_for_select(@contract_conservators, "id", "key"), { prompt: 'Select Vendor' }, { :class => 'form-control' }) %>
+            <%= form.select(:performed_by_vendor_id, options_from_collection_for_select(@contract_conservators, "id", "key"), { prompt: 'Select Vendor' }, { :class => 'form-control' }) %>
           </div>
           <div class="form-group">
             <label>Repair Type</label>
             <%= form.select :repair_type, options_from_collection_for_select(@repair_types, "id", "key"), { prompt: 'Select Repair Type' }, { :class => 'form-control' } %>
           </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <%= form.submit "Create External Repair Record", class: "btn btn-primary" %>
-        <% end %>
-      </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <%= form.submit "Create External Repair Record", class: "btn btn-primary" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
fixes: #32 
Before, if you landed on a conservation record page from a link on the main page the form wouldn't work without refreshing the page.  The div of the modal's body started before the form and ended with-in the form.  Something about this caused the button to be placed outside of the form tag.

I moved the div of the modal body into the form and it appears to be working well.