### PR TITLE
Add user management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler -v 2.0.1
+            gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 
       - run:
           name: Install Dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'pdfkit'
 
 gem 'dotenv-rails'
 
+gem 'cancancan'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development do
   gem 'rubocop'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -64,10 +64,10 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'rb-readline'
   gem 'rubocop'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'dotenv-rails'
 
 gem 'cancancan'
 
+gem 'administrate'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'coveralls'
+  gem 'database_cleaner'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rb-readline (0.5.5)
     regexp_parser (1.5.1)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
@@ -292,6 +293,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails-controller-testing
+  rb-readline
   rspec-rails (~> 3.8)
   rubocop
   sass-rails (~> 5.0)
@@ -308,4 +310,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     devise (4.6.2)
@@ -314,6 +315,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
   coveralls
+  database_cleaner
   devise
   dotenv-rails
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,17 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    administrate (0.12.0)
+      actionpack (>= 4.2)
+      actionview (>= 4.2)
+      activerecord (>= 4.2)
+      autoprefixer-rails (>= 6.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.6.0)
@@ -82,6 +93,8 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.4)
+    datetime_picker_rails (0.0.7)
+      momentjs-rails (>= 2.8.1)
     devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -114,6 +127,18 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -130,6 +155,8 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    momentjs-rails (2.20.1)
+      railties (>= 3.1)
     msgpack (1.2.10)
     nio4r (2.3.1)
     nokogiri (1.10.3)
@@ -229,6 +256,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selectize-rails (0.12.6)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -278,6 +306,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  administrate
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.2.3)
     byebug (11.0.1)
+    cancancan (1.17.0)
     capybara (3.22.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -280,6 +281,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
   byebug
+  cancancan
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
   coveralls

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,32 @@
+# All Administrate controllers inherit from this `Admin::ApplicationController`,
+# making it the ideal place to put authentication logic or other
+# before_actions.
+#
+# If you want to add pagination or other controller-level concerns,
+# you're free to overwrite the RESTful controller actions.
+module Admin
+  class ApplicationController < Administrate::ApplicationController
+    before_action :authenticate_admin
+
+    def authenticate_admin
+      send(:authenticate_user!)
+    end
+
+  load_and_authorize_resource
+    # Override this value to specify the number of elements to display at a time
+    # on index pages. Defaults to 20.
+    # def records_per_page
+    #   params[:per_page] || 20
+    # end
+
+		# Raise an exception if the user is not permitted to access this resource
+		def authorize_resource(resource)
+			raise "Erg!" unless show_action?(params[:action], resource)
+		end
+
+		# Hide links to actions if the user is not allowed to do them      
+		def show_action?(action, resource)
+			can? action, resource
+		end
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # All Administrate controllers inherit from this `Admin::ApplicationController`,
 # making it the ideal place to put authentication logic or other
 # before_actions.
@@ -12,21 +14,21 @@ module Admin
       send(:authenticate_user!)
     end
 
-  load_and_authorize_resource
+    load_and_authorize_resource
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.
     # def records_per_page
     #   params[:per_page] || 20
     # end
 
-		# Raise an exception if the user is not permitted to access this resource
-		def authorize_resource(resource)
-			raise "Erg!" unless show_action?(params[:action], resource)
-		end
+    # Raise an exception if the user is not permitted to access this resource
+    def authorize_resource(resource)
+      raise 'Erg!' unless show_action?(params[:action], resource)
+    end
 
-		# Hide links to actions if the user is not allowed to do them      
-		def show_action?(action, resource)
-			can? action, resource
-		end
+    # Hide links to actions if the user is not allowed to do them
+    def show_action?(action, resource)
+      can? action, resource
+    end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module Admin
   class UsersController < Admin::ApplicationController
-
-  load_and_authorize_resource
+    load_and_authorize_resource
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,36 @@
+module Admin
+  class UsersController < Admin::ApplicationController
+
+  load_and_authorize_resource
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   foo = Foo.find(params[:id])
+    #   foo.update(params[:foo])
+    #   send_foo_updated_email
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #  if current_user.super_admin?
+    #    resource_class
+    #  else
+    #    resource_class.with_less_stuff
+    #  end
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,5 +11,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:display_name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:role])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:display_name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:role])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:role, :display_name])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:display_name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:role, :display_name])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[role display_name])
   end
 end

--- a/app/controllers/conservation_records_controller.rb
+++ b/app/controllers/conservation_records_controller.rb
@@ -5,6 +5,8 @@ class ConservationRecordsController < ApplicationController
   before_action :set_conservation_record, only: %i[show edit update destroy]
   before_action :set_departments
 
+  load_and_authorize_resource
+
   # GET /conservation_records
   # GET /conservation_records.json
   def index

--- a/app/controllers/controlled_vocabularies_controller.rb
+++ b/app/controllers/controlled_vocabularies_controller.rb
@@ -4,6 +4,8 @@ class ControlledVocabulariesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_controlled_vocabulary, only: %i[show edit update destroy]
 
+  load_and_authorize_resource
+
   # GET /controlled_vocabularies
   # GET /controlled_vocabularies.json
   def index

--- a/app/controllers/external_repair_records_controller.rb
+++ b/app/controllers/external_repair_records_controller.rb
@@ -3,9 +3,11 @@
 class ExternalRepairRecordsController < ApplicationController
   before_action :authenticate_user!
 
+  load_and_authorize_resource
+
   def create
     @conservation_record = ConservationRecord.find(params[:conservation_record_id])
-    @repair_record = @conservation_record.external_repair_records.create(err_params)
+    @repair_record = @conservation_record.external_repair_records.create(create_params)
     redirect_to conservation_record_path(@conservation_record)
   end
 
@@ -18,7 +20,7 @@ class ExternalRepairRecordsController < ApplicationController
 
   private
 
-  def err_params
+  def create_params
     params.require(:external_repair_record).permit(:performed_by_vendor_id, :repair_type)
   end
 end

--- a/app/controllers/in_house_repair_records_controller.rb
+++ b/app/controllers/in_house_repair_records_controller.rb
@@ -3,9 +3,11 @@
 class InHouseRepairRecordsController < ApplicationController
   before_action :authenticate_user!
 
+  load_and_authorize_resource
+
   def create
     @conservation_record = ConservationRecord.find(params[:conservation_record_id])
-    @repair_record = @conservation_record.in_house_repair_records.create(ihrr_params)
+    @repair_record = @conservation_record.in_house_repair_records.create(create_params)
     redirect_to conservation_record_path(@conservation_record)
   end
 
@@ -18,7 +20,7 @@ class InHouseRepairRecordsController < ApplicationController
 
   private
 
-  def ihrr_params
+  def create_params
     params.require(:in_house_repair_record).permit(:performed_by_user_id, :repair_type, :minutes_spent)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,10 +24,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     authorize! :assign_roles, @user if params[:user][:assign_roles]
   end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+   def destroy
+     authorize! :destroy, @user
+     super
+   end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,62 +1,64 @@
 # frozen_string_literal: true
 
-class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+class Users
+  class RegistrationsController < Devise::RegistrationsController
+    # before_action :configure_sign_up_params, only: [:create]
+    # before_action :configure_account_update_params, only: [:update]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+    # GET /resource/sign_up
+    # def new
+    #   super
+    # end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+    # POST /resource
+    # def create
+    #   super
+    # end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+    # GET /resource/edit
+    # def edit
+    #   super
+    # end
 
-  def update
-    super
-    authorize! :assign_roles, @user if params[:user][:assign_roles]
+    def update
+      super
+      authorize! :assign_roles, @user if params[:user][:assign_roles]
+    end
+
+    def destroy
+      authorize! :destroy, @user
+      super
+    end
+
+    # GET /resource/cancel
+    # Forces the session data which is usually expired after sign
+    # in to be expired now. This is useful if the user wants to
+    # cancel oauth signing in/up in the middle of the process,
+    # removing all OAuth session data.
+    # def cancel
+    #   super
+    # end
+
+    # protected
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    # end
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_account_update_params
+    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    # end
+
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
   end
-
-   def destroy
-     authorize! :destroy, @user
-     super
-   end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  def update
+    super
+    authorize! :assign_roles, @user if params[:user][:assign_roles]
+  end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -1,0 +1,74 @@
+require "administrate/base_dashboard"
+
+class UserDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    email: Field::String,
+    encrypted_password: Field::String,
+    reset_password_token: Field::String,
+    reset_password_sent_at: Field::DateTime,
+    remember_created_at: Field::DateTime,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    display_name: Field::String,
+    role: Field::Select.with_options(collection: User::ROLES)
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+  id
+  display_name
+  email
+  role
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+  id
+  email
+  remember_created_at
+  created_at
+  updated_at
+  display_name
+  role
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+  email
+  display_name
+  role
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how users are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(user)
+  #   "User ##{user.id}"
+  # end
+end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -1,4 +1,6 @@
-require "administrate/base_dashboard"
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
 
 class UserDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -26,31 +28,31 @@ class UserDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-  id
-  display_name
-  email
-  role
+    id
+    display_name
+    email
+    role
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  id
-  email
-  remember_created_at
-  created_at
-  updated_at
-  display_name
-  role
+    id
+    email
+    remember_created_at
+    created_at
+    updated_at
+    display_name
+    role
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  email
-  display_name
-  role
+    email
+    display_name
+    role
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,32 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user 
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on. 
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/ryanb/cancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -35,6 +35,7 @@ class Ability
     if user.role == 'admin'
       can :manage, :all
       can :assign_roles, User
+      cannot :create, User
     elsif user.role == 'standard'
       can :crud, [ConservationRecord, ControlledVocabulary, ExternalRepairRecord, InHouseRepairRecord]
     elsif user.role == 'read_only'  

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,5 +28,17 @@ class Ability
     #
     # See the wiki for details:
     # https://github.com/ryanb/cancan/wiki/Defining-Abilities
+    user ||= User.new # guest user (not logged in)
+
+    alias_action :create, :read, :update, :destroy, :to => :crud
+
+    if user.role == 'admin'
+      can :manage, :all
+      can :assign_roles, User
+    elsif user.role == 'standard'
+      can :crud, [ConservationRecord, ControlledVocabulary, ExternalRepairRecord, InHouseRepairRecord]
+    elsif user.role == 'read_only'  
+      can :read, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord]
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,36 +1,12 @@
+# frozen_string_literal: true
+
 class Ability
   include CanCan::Ability
 
-  def initialize(user)
-    # Define abilities for the passed in user here. For example:
-    #
-    #   user ||= User.new # guest user (not logged in)
-    #   if user.admin?
-    #     can :manage, :all
-    #   else
-    #     can :read, :all
-    #   end
-    #
-    # The first argument to `can` is the action you are giving the user 
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on. 
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/ryanb/cancan/wiki/Defining-Abilities
+  def initialize(user) # rubocop:disable Metrics/MethodLength
     user ||= User.new # guest user (not logged in)
 
-    alias_action :create, :read, :update, :destroy, :to => :crud
+    alias_action :create, :read, :update, :destroy, to: :crud
 
     if user.role == 'admin'
       can :manage, :all
@@ -38,7 +14,7 @@ class Ability
       cannot :create, User
     elsif user.role == 'standard'
       can :crud, [ConservationRecord, ControlledVocabulary, ExternalRepairRecord, InHouseRepairRecord]
-    elsif user.role == 'read_only'  
+    elsif user.role == 'read_only'
       can :read, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord]
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  before_save :default_role
+
+  ROLES = %w[admin standard read_only].freeze
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
   validates :display_name, presence: true
+
+  def default_role
+    self.role ||= 'read_only'
+  end
 end

--- a/app/views/conservation_records/index.html.erb
+++ b/app/views/conservation_records/index.html.erb
@@ -1,6 +1,8 @@
 <div class="header">
   <h1>Conservation Records</h1>
-  <%= link_to 'Add Conservation Record', new_conservation_record_path %>
+  <% if can? :create, ConservationRecord %>
+    <%= link_to 'Add Conservation Record', new_conservation_record_path %>
+  <% end %>
 </div>
 
 <p></p>
@@ -26,8 +28,11 @@
         <td><%= conservation_record.call_number %></td>
         <td><%= conservation_record.item_record_number %></td>
         <td><%= link_to 'Show', conservation_record %></td>
-        <td><%= link_to 'Edit', edit_conservation_record_path(conservation_record) %></td>
+
+        <% if can? :crud, ConservationRecord %>
+          <td><%= link_to 'Edit', edit_conservation_record_path(conservation_record) %></td>
         <td><%= link_to 'Destroy', conservation_record, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/conservation_records/show.html.erb
+++ b/app/views/conservation_records/show.html.erb
@@ -1,7 +1,9 @@
 <%= link_to '← Return to List', conservation_records_path %>
 <div class="header">
   <h1><%= @conservation_record.title %></h1>
-  <%= link_to 'Edit Conservation Record', edit_conservation_record_path(@conservation_record) %>
+  <% if can? :crud, ConservationRecord %>
+    <%= link_to 'Edit Conservation Record', edit_conservation_record_path(@conservation_record) %>
+  <% end %>
 </div>
 
 <%= link_to 'Download Conservation Worksheet', conservation_worksheet_path(@conservation_record), target: "_blank" %>
@@ -58,9 +60,11 @@
     
     <div class="header">
       <h3>In-House Repairs</h3>
-      <button type="button" class="btn btn-primary cta-btn" data-toggle="modal" data-target="#inHouseRepairModal">
-        Add In-House Repairs
-      </button>
+      <% if can? :crud, InHouseRepairRecord %>
+        <button type="button" class="btn btn-primary cta-btn" data-toggle="modal" data-target="#inHouseRepairModal">
+          Add In-House Repairs
+        </button>
+      <% end %>
     </div>
     <% if @in_house_repairs.count == 0 %>
       <div class="card">
@@ -86,9 +90,11 @@
     <br />
     <div class="header">
       <h3>External Repairs</h3>
-      <button type="button" class="btn btn-primary cta-btn" data-toggle="modal" data-target="#externalRepairModal">
-        Add External Repair
-      </button>
+      <% if can? :crud, ExternalRepairRecord %>
+        <button type="button" class="btn btn-primary cta-btn" data-toggle="modal" data-target="#externalRepairModal">
+          Add External Repair
+        </button>
+      <% end %>
     </div>
     <% if @external_repairs.count == 0 %>
       <div class="card">

--- a/app/views/controlled_vocabularies/index.html.erb
+++ b/app/views/controlled_vocabularies/index.html.erb
@@ -2,7 +2,11 @@
 
 <h1>Controlled Vocabularies</h1>
 
-<p><%= link_to 'New Controlled Vocabulary', new_controlled_vocabulary_path %></p>
+<p>
+  <% if can? :create, ControlledVocabulary %>
+    <%= link_to 'New Controlled Vocabulary', new_controlled_vocabulary_path %>
+  <% end %>
+</p>
 
 
 <table class="table">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,6 +12,14 @@
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
+
+  <% if can? :assign_roles, @user %>
+    <div class="field">
+      <%= f.label :role %><br />
+      <%= f.collection_select :role, User::ROLES, :to_s, :humanize %>
+    </div>
+  <% end %>
+
   <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,22 +2,18 @@
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+  <div class="field">
+    <%= f.label :display_name %><br />
+    <%= f.text_field :display_name, autofocus: true %>
+  </div>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-
-  <% if can? :assign_roles, @user %>
-    <div class="field">
-      <%= f.label :role %><br />
-      <%= f.collection_select :role, User::ROLES, :to_s, :humanize %>
-    </div>
   <% end %>
 
   <div class="field">
@@ -43,9 +39,5 @@
     <%= f.submit "Update" %>
   </div>
 <% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -1,0 +1,47 @@
+<%#
+# Application Layout
+
+This view template is used as the layout
+for every page that Administrate generates.
+
+By default, it renders:
+- Navigation
+- Content for a search bar
+  (if provided by a `content_for` block in a nested page)
+- Flashes
+- Links to stylesheets and JavaScripts
+%>
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+<head>
+  <meta charset="utf-8">
+  <meta name="ROBOTS" content="NOODP">
+  <meta name="viewport" content="initial-scale=1">
+  <title>
+    <%= content_for(:title) %> - <%= application_title %>
+  </title>
+  <%= render "stylesheet" %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+
+  <%= render 'shared/navigation' %>
+  <%= render "icons" %>
+
+  <div class="app-container">
+
+  <!--  Hide sidebar with model listng
+        since we're only managing users
+    <%= render 'navigation' %>
+  -->
+    <main class="main-content" role="main">
+      <%= render "flashes" -%>
+      <%= yield %>
+    </main>
+  </div>
+
+  <%= render "javascript" %>
+</body>
+</html>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -15,6 +15,13 @@
             <%= link_to('Vocabularies', controlled_vocabularies_path, class: 'nav-link') %>
           </li>
         <% end %>
+        <% if can? :manage, User %>
+          <li class="nav-item">
+            <%= link_to('Users', admin_users_path, class: 'nav-link') %>
+          </li>
+        <% end %>
+ 
+
         <li class="nav-item">
           <%= form_with url: '/search', method: :get, local: true, class: "form-inline" do |f| %>
             <%= f.text_field :search, id: :search, value: params[:search], placeholder: "Search", class: "form-control mr-sm-2" %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -5,12 +5,16 @@
         <li class="nav-item">
           <%= link_to 'Treatment Database', root_path, class: 'navbar-brand' %>
         </li>
-        <li class="nav-item">
-          <%= link_to('Conservation Records', conservation_records_path, class: 'nav-link') %>
-        </li>
-        <li class="nav-item">
-          <%= link_to('Vocabularies', controlled_vocabularies_path, class: 'nav-link') %>
-        </li>
+        <% if can? :read, ConservationRecord %>
+          <li class="nav-item">
+            <%= link_to('Conservation Records', conservation_records_path, class: 'nav-link') %>
+          </li>
+        <% end %>
+        <% if can? :read, ControlledVocabulary %>
+          <li class="nav-item">
+            <%= link_to('Vocabularies', controlled_vocabularies_path, class: 'nav-link') %>
+          </li>
+        <% end %>
         <li class="nav-item">
           <%= form_with url: '/search', method: :get, local: true, class: "form-inline" do |f| %>
             <%= f.text_field :search, id: :search, value: params[:search], placeholder: "Search", class: "form-control mr-sm-2" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,11 @@
 
 Rails.application.routes.draw do
   namespace :admin do
-      resources :users
+    resources :users
 
-      root to: "users#index"
-    end
-  devise_for :users, controllers: { registrations: 'users/registrations' }  
+    root to: 'users#index'
+  end
+  devise_for :users, controllers: { registrations: 'users/registrations' }
 
   resources :controlled_vocabularies
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  devise_for :users, controllers: { registrations: 'users/registrations' }  
+
   resources :controlled_vocabularies
+
   resources :conservation_records do
     resources :in_house_repair_records
     resources :external_repair_records
   end
+
   get 'search/help'
   get 'search', to: 'search#results', as: 'search'
   root 'front#index'
   get 'front/index'
   get 'conservation_records/:id/conservation_worksheet', to: 'conservation_records#conservation_worksheet', as: 'conservation_worksheet'
-  devise_for :users
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :admin do
+      resources :users
+
+      root to: "users#index"
+    end
   devise_for :users, controllers: { registrations: 'users/registrations' }  
 
   resources :controlled_vocabularies

--- a/db/migrate/20191204011151_add_role_to_users.rb
+++ b/db/migrate/20191204011151_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_205510) do
+ActiveRecord::Schema.define(version: 2019_12_04_011151) do
 
   create_table "conservation_records", force: :cascade do |t|
     t.date "date_recieved_in_preservation_services"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2019_07_26_205510) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "display_name"
+    t.string "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/conservation_records_controller_spec.rb
+++ b/spec/controllers/conservation_records_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
   render_views
 
   before do
-    user = create(:user)
+    user = create(:user, role: 'admin')
     sign_in_user(user)
   end
 

--- a/spec/controllers/controlled_vocabularies_controller_spec.rb
+++ b/spec/controllers/controlled_vocabularies_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ControlledVocabulariesController, type: :controller do
   end
 
   before do
-    user = create(:user)
+    user = create(:user, role: 'standard')
     sign_in_user(user)
   end
 

--- a/spec/controllers/external_repair_records_controller_spec.rb
+++ b/spec/controllers/external_repair_records_controller_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe ExternalRepairRecordsController, type: :controller do
   render_views
 
   before do
-    user = create(:user)
+    user = create(:user, role: 'standard')
     sign_in user
   end
 
   let(:conservation_record) { create(:conservation_record) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, role: 'standard') }
   let(:repair_type) { create(:controlled_vocabulary) }
   let(:vendor) { create(:vendor) }
   let(:valid_attributes) do

--- a/spec/controllers/in_house_repair_records_controller_spec.rb
+++ b/spec/controllers/in_house_repair_records_controller_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe InHouseRepairRecordsController, type: :controller do
   render_views
 
   before do
-    user = create(:user)
+    user = create(:user, role: 'standard')
     sign_in user
   end
 
   let(:conservation_record) { create(:conservation_record) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, role: 'standard') }
   let(:repair_type) { create(:controlled_vocabulary) }
   let(:valid_attributes) do
     {

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SearchController, type: :controller do
   render_views
 
   before do
-    create(:conservation_record)
+    create(:conservation_record, id: 1)
     create(:conservation_record, item_record_number: 'i1001')
     create(:conservation_record, title: 'Third Title')
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SearchController, type: :controller do
   render_views
 
   before do
-    create(:conservation_record, id: 1)
+    create(:conservation_record)
     create(:conservation_record, item_record_number: 'i1001')
     create(:conservation_record, title: 'Third Title')
   end

--- a/spec/factories/conservation_records.rb
+++ b/spec/factories/conservation_records.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :conservation_record do
     date_recieved_in_preservation_services { '2019-06-11' }
-    department { ControlledVocabulary.where(vocabulary: 'department').order('RANDOM()').first.id }
+    department { ControlledVocabulary.where(vocabulary: 'department').order(Arel.sql('random()')).first.id }
     title { 'The Illiad' }
     author { 'James Joyce' }
     imprint { 'Dutton' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:display_name) { |n| "Name #{n}" }
     sequence(:email) { |n| "user#{n}@example.com" }
     password { 'notapassword' }
+    role { 'standard' }
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe "User", type: :model do
+  describe "abilities" do
+    subject(:ability) { Ability.new(user) }
+    let(:user){ nil }
+
+    context "when is an admin" do
+      let(:user){ build(:user, role: 'admin') }
+      it { is_expected.to be_able_to(:manage, User.new) }
+    end
+
+    context "when is a standard user" do
+      let(:user){ build(:user, role: 'standard') }
+
+      it { is_expected.not_to be_able_to(:index, User.new) }
+      it { is_expected.not_to be_able_to(:create, User.new) }
+      it { is_expected.not_to be_able_to(:read, User.new) }
+      it { is_expected.not_to be_able_to(:update, User.new) }
+      it { is_expected.not_to be_able_to(:destroy, User.new) }
+
+      it { is_expected.to be_able_to(:index, ConservationRecord.new) }
+      it { is_expected.to be_able_to(:read, ConservationRecord.new) }
+      it { is_expected.to be_able_to(:create, ConservationRecord.new) }
+      it { is_expected.to be_able_to(:update, ConservationRecord.new) }
+      it { is_expected.to be_able_to(:destroy, ConservationRecord.new) }
+
+      it { is_expected.to be_able_to(:index, ControlledVocabulary.new) }
+      it { is_expected.to be_able_to(:create, ControlledVocabulary.new) }
+      it { is_expected.to be_able_to(:read, ControlledVocabulary.new) }
+      it { is_expected.to be_able_to(:update, ControlledVocabulary.new) }
+      it { is_expected.to be_able_to(:destroy, ControlledVocabulary.new) }
+    end
+
+    context "when is a read_only user" do
+      let(:user){ build(:user, role: 'read_only') }
+
+      it { is_expected.not_to be_able_to(:create, User.new) }
+      it { is_expected.not_to be_able_to(:read, User.new) }
+      it { is_expected.not_to be_able_to(:update, User.new) }
+      it { is_expected.not_to be_able_to(:destroy, User.new) }
+
+      it { is_expected.to be_able_to(:index, ConservationRecord.new) }
+      it { is_expected.to be_able_to(:read, ConservationRecord.new) }
+      it { is_expected.not_to be_able_to(:create, ConservationRecord.new) }
+      it { is_expected.not_to be_able_to(:update, ConservationRecord.new) }
+      it { is_expected.not_to be_able_to(:destroy, ConservationRecord.new) }
+
+      it { is_expected.not_to be_able_to(:index, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:create, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:read, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:update, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:destroy, ControlledVocabulary.new) }
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -3,21 +3,20 @@
 require 'rails_helper'
 require 'cancan/matchers'
 
-describe "User", type: :model do
-  describe "abilities" do
+describe 'User', type: :model do
+  describe 'abilities' do
     subject(:ability) { Ability.new(user) }
-    let(:user){ nil }
+    let(:user) { nil }
 
-    context "when is an admin" do
-      let(:user){ build(:user, role: 'admin') }
+    context 'when is an admin' do
+      let(:user) { build(:user, role: 'admin') }
       it { is_expected.to be_able_to(:manage, User.new) }
       it { is_expected.to be_able_to(:index, Admin) }
       it { is_expected.not_to be_able_to(:create, User) }
-
     end
 
-    context "when is a standard user" do
-      let(:user){ build(:user, role: 'standard') }
+    context 'when is a standard user' do
+      let(:user) { build(:user, role: 'standard') }
 
       it { is_expected.not_to be_able_to(:index, User.new) }
       it { is_expected.not_to be_able_to(:create, User.new) }
@@ -39,8 +38,8 @@ describe "User", type: :model do
       it { is_expected.to be_able_to(:destroy, ControlledVocabulary.new) }
     end
 
-    context "when is a read_only user" do
-      let(:user){ build(:user, role: 'read_only') }
+    context 'when is a read_only user' do
+      let(:user) { build(:user, role: 'read_only') }
 
       it { is_expected.not_to be_able_to(:create, User.new) }
       it { is_expected.not_to be_able_to(:read, User.new) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,6 +11,9 @@ describe "User", type: :model do
     context "when is an admin" do
       let(:user){ build(:user, role: 'admin') }
       it { is_expected.to be_able_to(:manage, User.new) }
+      it { is_expected.to be_able_to(:index, Admin) }
+      it { is_expected.not_to be_able_to(:create, User) }
+
     end
 
     context "when is a standard user" do
@@ -21,6 +24,7 @@ describe "User", type: :model do
       it { is_expected.not_to be_able_to(:read, User.new) }
       it { is_expected.not_to be_able_to(:update, User.new) }
       it { is_expected.not_to be_able_to(:destroy, User.new) }
+      it { is_expected.not_to be_able_to(:index, Admin) }
 
       it { is_expected.to be_able_to(:index, ConservationRecord.new) }
       it { is_expected.to be_able_to(:read, ConservationRecord.new) }
@@ -42,6 +46,7 @@ describe "User", type: :model do
       it { is_expected.not_to be_able_to(:read, User.new) }
       it { is_expected.not_to be_able_to(:update, User.new) }
       it { is_expected.not_to be_able_to(:destroy, User.new) }
+      it { is_expected.not_to be_able_to(:index, Admin) }
 
       it { is_expected.to be_able_to(:index, ConservationRecord.new) }
       it { is_expected.to be_able_to(:read, ConservationRecord.new) }

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'ControlledVocabularies', type: :request do
   before do
-    user = create(:user)
+    user = create(:user, role: 'standard')
     sign_in user
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,8 @@ require 'byebug'
 
 require 'devise'
 
+require 'database_cleaner'
+
 def sign_in(user)
   post user_session_path \
     'user[email]' => user.email,
@@ -40,6 +42,20 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+
+  config.before do |example|
+    if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.start
+    end
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'conservation_records/index', type: :view do
-
-include Devise::Test::ControllerHelpers
+  include Devise::Test::ControllerHelpers
 
   before(:each) do
     assign(:conservation_records, [
@@ -49,12 +48,12 @@ include Devise::Test::ControllerHelpers
   end
 
   it 'hides controls for read_only users' do
-      @user = create(:user, role: 'read_only')
-      @request.env['devise.mapping'] = Devise.mappings[:user]
-      sign_in @user
-      render
-      expect(rendered).not_to have_link('New Conservation Record')
-      expect(rendered).not_to have_link('Edit')
-      expect(rendered).not_to have_link('Destroy')
+    @user = create(:user, role: 'read_only')
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    sign_in @user
+    render
+    expect(rendered).not_to have_link('New Conservation Record')
+    expect(rendered).not_to have_link('Edit')
+    expect(rendered).not_to have_link('Destroy')
   end
 end

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'conservation_records/index', type: :view do
+
+include Devise::Test::ControllerHelpers
+
   before(:each) do
     assign(:conservation_records, [
              ConservationRecord.create!(
@@ -30,6 +33,10 @@ RSpec.describe 'conservation_records/index', type: :view do
            ])
   end
 
+  after(:all) do
+    ConservationRecord.all.delete_all
+  end
+
   it 'renders a list of conservation_records' do
     render
     assert_select 'td', text: '101', count: 1
@@ -39,5 +46,15 @@ RSpec.describe 'conservation_records/index', type: :view do
     assert_select 'td', text: 'Author', count: 2
     assert_select 'td', text: 'Call Number', count: 2
     assert_select 'td', text: 'Item Record Number', count: 2
+  end
+
+  it 'hides controls for read_only users' do
+      @user = create(:user, role: 'read_only')
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in @user
+      render
+      expect(rendered).not_to have_link('New Conservation Record')
+      expect(rendered).not_to have_link('Edit')
+      expect(rendered).not_to have_link('Destroy')
   end
 end

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe 'conservation_records/index', type: :view do
            ])
   end
 
-  after(:all) do
-    ConservationRecord.all.delete_all
-  end
-
   it 'renders a list of conservation_records' do
     render
     assert_select 'td', text: '101', count: 1

--- a/spec/views/conservation_records/show.html.erb_spec.rb
+++ b/spec/views/conservation_records/show.html.erb_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'conservation_records/show', type: :view do
-
-include Devise::Test::ControllerHelpers
+  include Devise::Test::ControllerHelpers
 
   before(:each) do
     @conservation_record = assign(:conservation_record, ConservationRecord.create!(
@@ -44,13 +43,12 @@ include Devise::Test::ControllerHelpers
   end
 
   it 'hides controls for read_only users' do
-      @user = create(:user, role: 'read_only')
-      @request.env['devise.mapping'] = Devise.mappings[:user]
-      sign_in @user
-      render
-      expect(rendered).not_to have_link('Edit Conservation Record')
-      expect(rendered).not_to have_button('Add In-House Repairs')
-      expect(rendered).not_to have_button('Add External Repair')
+    @user = create(:user, role: 'read_only')
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    sign_in @user
+    render
+    expect(rendered).not_to have_link('Edit Conservation Record')
+    expect(rendered).not_to have_button('Add In-House Repairs')
+    expect(rendered).not_to have_button('Add External Repair')
   end
-
 end

--- a/spec/views/conservation_records/show.html.erb_spec.rb
+++ b/spec/views/conservation_records/show.html.erb_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'conservation_records/show', type: :view do
+
+include Devise::Test::ControllerHelpers
+
   before(:each) do
     @conservation_record = assign(:conservation_record, ConservationRecord.create!(
                                                           date_recieved_in_preservation_services: Date.new,
@@ -39,4 +42,15 @@ RSpec.describe 'conservation_records/show', type: :view do
     render
     expect(rendered).to have_link('Download Conservation Worksheet')
   end
+
+  it 'hides controls for read_only users' do
+      @user = create(:user, role: 'read_only')
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in @user
+      render
+      expect(rendered).not_to have_link('Edit Conservation Record')
+      expect(rendered).not_to have_button('Add In-House Repairs')
+      expect(rendered).not_to have_button('Add External Repair')
+  end
+
 end

--- a/spec/views/controlled_vocabularies/index.html.erb_spec.rb
+++ b/spec/views/controlled_vocabularies/index.html.erb_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'controlled_vocabularies/index', type: :view do
+
+include Devise::Test::ControllerHelpers
+
   before(:each) do
     assign(:controlled_vocabularies, [
              ControlledVocabulary.create!(

--- a/spec/views/controlled_vocabularies/index.html.erb_spec.rb
+++ b/spec/views/controlled_vocabularies/index.html.erb_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'controlled_vocabularies/index', type: :view do
-
-include Devise::Test::ControllerHelpers
+  include Devise::Test::ControllerHelpers
 
   before(:each) do
     assign(:controlled_vocabularies, [

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
   include Devise::Test::ControllerHelpers
 
   context 'when user is admin' do
-
     before do
       @user = create(:user, role: 'admin')
       @request.env['devise.mapping'] = Devise.mappings[:user]
@@ -50,7 +49,4 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).to have_link('Log out')
     end
   end
-
-
-
 end

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -5,15 +5,52 @@ require 'rails_helper'
 RSpec.describe 'shared/_navigation.html.erb', type: :view do
   include Devise::Test::ControllerHelpers
 
-  before do
-    create(:user)
-    render
+  context 'when user is admin' do
+
+    before do
+      @user = create(:user, role: 'admin')
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in @user
+      render
+    end
+
+    it 'has a menu with the expected links when signed out' do
+      expect(rendered).to have_link('Conservation Records')
+      expect(rendered).to have_link('Vocabularies')
+      expect(rendered).to have_link('Log out')
+    end
   end
 
-  it 'has a menu with the expected links when signed out' do
-    expect(rendered).to have_link('Conservation Records')
-    expect(rendered).to have_link('Vocabularies')
-    expect(rendered).to have_link('Log in')
-    expect(rendered).to have_link('Sign up')
+  context 'when user is standard' do
+    before do
+      @user = create(:user, role: 'standard')
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in @user
+      render
+    end
+
+    it 'has a menu with the expected links when signed out' do
+      expect(rendered).to have_link('Conservation Records')
+      expect(rendered).to have_link('Vocabularies')
+      expect(rendered).to have_link('Log out')
+    end
   end
+
+  context 'when user is read_only' do
+    before do
+      @user = create(:user, role: 'read_only')
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in @user
+      render
+    end
+
+    it 'has a menu with the expected links when signed out' do
+      expect(rendered).to have_link('Conservation Records')
+      expect(rendered).not_to have_link('Vocabularies')
+      expect(rendered).to have_link('Log out')
+    end
+  end
+
+
+
 end


### PR DESCRIPTION
Resolves #10 
Resolves #17 

Adds abilities and roles for users as well as a user admin dashboard for user management tasks. Admin role can edit name, email, and role of any user. Hides controls for actions for which users are not authorized.

* add and configure cancancan gem for abilities
* add and configure administration gem for dashboard functionality