### PR TITLE
display current user in nav

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -42,10 +42,13 @@
       </li>
       <% else %>
       <li class="nav-item">
-        <%= link_to('Edit account', edit_user_registration_path, class: 'nav-link') %>
-      </li>
-      <li class="nav-item">
-        <%= link_to('Log out', destroy_user_session_path, method: :delete, class: 'nav-link') %>
+				<div class="dropdown">
+					<a class="dropdown-toggle nav-link" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= current_user.display_name %></a>
+					<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+						<%= link_to("Edit account", edit_user_registration_path, class: 'dropdown-item') %>
+						<%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'dropdown-item') %>
+					</div>
+				</div>
       </li>
       <% end %>
     </ul>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -42,13 +42,15 @@
       </li>
       <% else %>
       <li class="nav-item">
-				<div class="dropdown">
-					<a class="dropdown-toggle nav-link" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= current_user.display_name %></a>
-					<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-						<%= link_to("Edit account", edit_user_registration_path, class: 'dropdown-item') %>
-						<%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'dropdown-item') %>
-					</div>
-				</div>
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= current_user.display_name %>
+          </button>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+            <%= link_to("Edit account", edit_user_registration_path, class: 'dropdown-item') %>
+            <%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'dropdown-item') %>
+          </div>
+        </div>
       </li>
       <% end %>
     </ul>

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).to have_link('Conservation Records')
       expect(rendered).to have_link('Vocabularies')
       expect(rendered).to have_link('Users')
-      expect(rendered).to have_link('Log out')
+      expect(rendered).to have_link('Edit account')
+      expect(rendered).to have_link('Logout')
     end
   end
 
@@ -33,7 +34,8 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).to have_link('Conservation Records')
       expect(rendered).to have_link('Vocabularies')
       expect(rendered).not_to have_link('Users')
-      expect(rendered).to have_link('Log out')
+      expect(rendered).to have_link('Edit account')
+      expect(rendered).to have_link('Logout')
     end
   end
 
@@ -49,7 +51,8 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).to have_link('Conservation Records')
       expect(rendered).not_to have_link('Vocabularies')
       expect(rendered).not_to have_link('Users')
-      expect(rendered).to have_link('Log out')
+      expect(rendered).to have_link('Edit account')
+      expect(rendered).to have_link('Logout')
     end
   end
 
@@ -64,6 +67,8 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).not_to have_link('Users')
       expect(rendered).to have_link('Log in')
       expect(rendered).to have_link('Sign up')
+      expect(rendered).not_to have_link('Edit account')
+      expect(rendered).not_to have_link('Logout')
     end
   end
 end


### PR DESCRIPTION
Resolves #56 

Display current user name in nav when logged in, drop-down menu items for edit and logout actions.
