### PR TITLE
#71, #72 Only permit admins to add and edit controlled vocabularies

### DIFF
--- a/app/controllers/controlled_vocabularies_controller.rb
+++ b/app/controllers/controlled_vocabularies_controller.rb
@@ -2,7 +2,7 @@
 
 class ControlledVocabulariesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_controlled_vocabulary, only: %i[show edit update destroy]
+  before_action :set_controlled_vocabulary, only: %i[show edit update]
 
   load_and_authorize_resource
 
@@ -51,16 +51,6 @@ class ControlledVocabulariesController < ApplicationController
         format.html { render :edit }
         format.json { render json: @controlled_vocabulary.errors, status: :unprocessable_entity }
       end
-    end
-  end
-
-  # DELETE /controlled_vocabularies/1
-  # DELETE /controlled_vocabularies/1.json
-  def destroy
-    @controlled_vocabulary.destroy
-    respond_to do |format|
-      format.html { redirect_to controlled_vocabularies_url, notice: 'Controlled vocabulary was successfully destroyed.' }
-      format.json { head :no_content }
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,9 +38,10 @@ class Ability
     if user.role == 'admin'
       can :manage, :all
       can :assign_roles, User
+      can :crud, [ControlledVocabulary]
     elsif user.role == 'standard'
       can :view_pdfs, [ConservationRecord]
-      can :crud, [ConservationRecord, ControlledVocabulary, ExternalRepairRecord, InHouseRepairRecord]
+      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord]
     elsif user.role == 'read_only'
       can :read, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord]
     end

--- a/app/views/controlled_vocabularies/index.html.erb
+++ b/app/views/controlled_vocabularies/index.html.erb
@@ -27,7 +27,6 @@
         <td><%= controlled_vocabulary.active %></td>
         <td><%= link_to 'Show', controlled_vocabulary %></td>
         <td><%= link_to 'Edit', edit_controlled_vocabulary_path(controlled_vocabulary) %></td>
-        <td><%= link_to 'Destroy', controlled_vocabulary, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations' }
 
   resources :users
-  resources :controlled_vocabularies
+  resources :controlled_vocabularies, except: [:destroy]
 
   resources :conservation_records do
     resources :in_house_repair_records

--- a/spec/controllers/controlled_vocabularies_controller_spec.rb
+++ b/spec/controllers/controlled_vocabularies_controller_spec.rb
@@ -150,19 +150,4 @@ RSpec.describe ControlledVocabulariesController, type: :controller do
       end
     end
   end
-
-  describe 'DELETE #destroy' do
-    it 'destroys the requested controlled_vocabulary' do
-      controlled_vocabulary = ControlledVocabulary.create! valid_attributes
-      expect do
-        delete :destroy, params: { id: controlled_vocabulary.to_param }, session: valid_session
-      end.to change(ControlledVocabulary, :count).by(-1)
-    end
-
-    it 'redirects to the controlled_vocabularies list' do
-      controlled_vocabulary = ControlledVocabulary.create! valid_attributes
-      delete :destroy, params: { id: controlled_vocabulary.to_param }, session: valid_session
-      expect(response).to redirect_to(controlled_vocabularies_url)
-    end
-  end
 end

--- a/spec/controllers/controlled_vocabularies_controller_spec.rb
+++ b/spec/controllers/controlled_vocabularies_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ControlledVocabulariesController, type: :controller do
   end
 
   before do
-    user = create(:user, role: 'standard')
+    user = create(:user, role: 'admin')
     sign_in_user(user)
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -28,11 +28,11 @@ describe 'User', type: :model do
       it { is_expected.to be_able_to(:update, ConservationRecord.new) }
       it { is_expected.to be_able_to(:destroy, ConservationRecord.new) }
 
-      it { is_expected.to be_able_to(:index, ControlledVocabulary.new) }
-      it { is_expected.to be_able_to(:create, ControlledVocabulary.new) }
-      it { is_expected.to be_able_to(:read, ControlledVocabulary.new) }
-      it { is_expected.to be_able_to(:update, ControlledVocabulary.new) }
-      it { is_expected.to be_able_to(:destroy, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:index, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:create, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:read, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:update, ControlledVocabulary.new) }
+      it { is_expected.not_to be_able_to(:destroy, ControlledVocabulary.new) }
     end
 
     context 'when is a read_only user' do

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'ControlledVocabularies', type: :request do
   end
 
   describe 'GET /controlled_vocabularies' do
-    it 'works! (now write some real specs)' do
+    it 'redirects to the homepage when requested by a standard user' do
       get controlled_vocabularies_path
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(302)
     end
   end
 end

--- a/spec/routing/controlled_vocabularies_routing_spec.rb
+++ b/spec/routing/controlled_vocabularies_routing_spec.rb
@@ -31,9 +31,5 @@ RSpec.describe ControlledVocabulariesController, type: :routing do
     it 'routes to #update via PATCH' do
       expect(patch: '/controlled_vocabularies/1').to route_to('controlled_vocabularies#update', id: '1')
     end
-
-    it 'routes to #destroy' do
-      expect(delete: '/controlled_vocabularies/1').to route_to('controlled_vocabularies#destroy', id: '1')
-    end
   end
 end

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
 
     it 'has a menu with the expected links when signed in' do
       expect(rendered).to have_link('Conservation Records')
-      expect(rendered).to have_link('Vocabularies')
+      expect(rendered).not_to have_link('Vocabularies')
       expect(rendered).not_to have_link('Users')
       expect(rendered).to have_link('Edit account')
       expect(rendered).to have_link('Logout')


### PR DESCRIPTION
Fixes: #71
Fixes: #72 

Changes logic and test to only allow admins to add and edit controlled vocabularies.

Also, prevents the deletion of controlled vocabularies.