### PR TITLE
#60 Allows standard users to download conservation worksheets and treatment reports

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,4 @@ Metrics/MethodLength:
   Exclude:
     - 'app/controllers/search_controller.rb'
     - 'app/controllers/treatment_reports_controller.rb'
+    - 'app/models/ability.rb'

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,11 +33,13 @@ class Ability
     user ||= User.new # guest user (not logged in)
 
     alias_action :create, :read, :update, :destroy, to: :crud
+    alias_action :treatment_report, :conservation_worksheet, to: :view_pdfs
 
     if user.role == 'admin'
       can :manage, :all
       can :assign_roles, User
     elsif user.role == 'standard'
+      can :view_pdfs, [ConservationRecord]
       can :crud, [ConservationRecord, ControlledVocabulary, ExternalRepairRecord, InHouseRepairRecord]
     elsif user.role == 'read_only'
       can :read, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord]

--- a/spec/controllers/conservation_records_controller_spec.rb
+++ b/spec/controllers/conservation_records_controller_spec.rb
@@ -189,5 +189,65 @@ RSpec.describe ConservationRecordsController, type: :controller do
       get :conservation_worksheet, params: { id: conservation_record.id }
       expect(response.headers['Content-Type']).to eq('application/pdf')
     end
+
+    context 'with read_only user' do
+      before do
+        read_user = create(:user, role: 'read_only')
+        sign_in_user(read_user)
+      end
+
+      it 'redirects to home with an error' do
+        conservation_record = ConservationRecord.create! valid_attributes
+        get :conservation_worksheet, params: { id: conservation_record.id }
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+    context 'with standard user' do
+      before do
+        standard_user = create(:user, role: 'standard')
+        sign_in_user(standard_user)
+      end
+
+      it 'sends a file' do
+        conservation_record = ConservationRecord.create! valid_attributes
+        get :conservation_worksheet, params: { id: conservation_record.id }
+        expect(response.headers['Content-Type']).to eq('application/pdf')
+      end
+    end
+  end
+
+  describe 'treatment_report' do
+    it 'sends a file' do
+      conservation_record = ConservationRecord.create! valid_attributes
+      get :treatment_report, params: { id: conservation_record.id }
+      expect(response.headers['Content-Type']).to eq('application/pdf')
+    end
+
+    context 'with read_only user' do
+      before do
+        read_user = create(:user, role: 'read_only')
+        sign_in_user(read_user)
+      end
+
+      it 'redirects to home with an error' do
+        conservation_record = ConservationRecord.create! valid_attributes
+        get :treatment_report, params: { id: conservation_record.id }
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+    context 'with standard user' do
+      before do
+        standard_user = create(:user, role: 'standard')
+        sign_in_user(standard_user)
+      end
+
+      it 'sends a file' do
+        conservation_record = ConservationRecord.create! valid_attributes
+        get :treatment_report, params: { id: conservation_record.id }
+        expect(response.headers['Content-Type']).to eq('application/pdf')
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #60 

We didn't have test coverage to ensure that both standard and admin users could download treatment reports and conservation worksheets, I read up on some of the CanCanCan documentation and have built out the tests a bit more.