### PR TITLE
#76 Add Conservators Note

### DIFF
--- a/app/controllers/treatment_reports_controller.rb
+++ b/app/controllers/treatment_reports_controller.rb
@@ -44,6 +44,7 @@ class TreatmentReportsController < ApplicationController
                                              :treatment_proposal_housing_provided_id,
                                              :treatment_proposal_housing_narrative,
                                              :treatment_proposal_storage_and_handling_notes,
-                                             :treatment_proposal_total_treatment_time)
+                                             :treatment_proposal_total_treatment_time,
+                                             :conservators_note)
   end
 end

--- a/app/views/conservation_records/show.html.erb
+++ b/app/views/conservation_records/show.html.erb
@@ -125,166 +125,23 @@
   </div>
 
   <br>
-  <div class="header">
-    <h3>Treatment Report</h3>
-    <%= link_to 'Download Treatment Report', treatment_report_path(@conservation_record), target: '_blank' %>
-  </div>
-  <br>
-  <ul class="nav nav-tabs" id="myTab" role="tablist">
+
+  <ul class="nav nav-pills" id="reportTab" role="tablist">
     <li class="nav-item">
-      <a class="nav-link active" id="description-tab" data-toggle="tab" href="#description" role="tab" aria-controls="description" aria-selected="true">Description</a>
+      <a class="nav-link active" id="treatment-report-tab" data-toggle="tab" href="#treatment-report" role="tab" aria-controls="Treatment Report" aria-selected="true">Treatment Report</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="condition-tab" data-toggle="tab" href="#condition" role="tab" aria-controls="condition" aria-selected="false">Condition</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" id="treatment-proposal-tab" data-toggle="tab" href="#treatment-proposal" role="tab" aria-controls="treatment-proposal" aria-selected="false">Treatment Proposal</a>
+      <a class="nav-link" id="conservators-note-tab" data-toggle="tab" href="#conservators-note" role="tab" aria-controls="Conservators Note" aria-selected="false">Conservator's Note</a>
     </li>
   </ul>
 
-  <%= form_with(model: [@conservation_record, @conservation_record.treatment_report], class: 'disable_input') do |f| %>
-  <div class="tab-content" id="myTabContent">
-    <div class="tab-pane fade show active" id="description" role="tabpanel" aria-labelledby="description-tab">
-      <div class="form-group">
-        <p>
-          General Remarks<br>
-          <%= f.text_area :description_general_remarks, class: 'form-control' %>
-        </p>
-
-        <p>
-          Binding<br>
-          <%= f.text_area :description_binding, class: 'form-control' %>
-        </p>
-
-        <p>
-          Textblock<br>
-          <%= f.text_area :description_textblock, class: 'form-control' %>
-        </p>
-
-        <p>
-          Primary Support<br>
-          <%= f.text_area :description_primary_support, class: 'form-control' %>
-        </p>
-
-        <p>
-          Medium<br>
-          <%= f.text_area :description_medium, class: 'form-control' %>
-        </p>
-
-        <p>
-          Attachments | Inserts<br>
-          <%= f.text_area :description_attachments_inserts, class: 'form-control' %>
-        </p>
-
-        <p>
-          Housing<br>
-          <%= f.text_area :description_housing, class: 'form-control' %>
-        </p>
-      </div>
-    </div>
-    <div class="tab-pane fade" id="condition" role="tabpanel" aria-labelledby="condition-tab">
-      <p>
-        Summary<br>
-        <%= f.text_area :condition_summary, class: 'form-control' %>
-      </p>
-
-      <p>
-        Binding<br>
-        <%= f.text_area :condition_binding, class: 'form-control' %>
-      </p>
-
-      <p>
-        Textblock<br>
-        <%= f.text_area :condition_textblock, class: 'form-control' %>
-      </p>
-
-      <p>
-        Primary Support<br>
-        <%= f.text_area :condition_primary_support, class: 'form-control' %>
-      </p>
-
-      <p>
-        Medium<br>
-        <%= f.text_area :condition_medium, class: 'form-control' %>
-      </p>
-
-      <p>
-        Housing<br>
-        <%= f.select(:condition_housing_id, options_from_collection_for_select(@housing, "id", "key"), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
-      </p>
-
-      <p>
-        Housing Narrative<br>
-        <%= f.text_area :condition_housing_narrative, class: 'form-control' %>
-      </p>
-
-      <p>
-        Attachments | Inserts<br>
-        <%= f.text_area :condition_attachments_inserts, class: 'form-control' %>
-      </p>
-
-      <p>
-        Previous Treatment<br>
-        <%= f.text_area :condition_previous_treatment, class: 'form-control' %>
-      </p>
-
-      <p>
-        Materials Analysis<br>
-        <%= f.text_area :condition_materials_analysis, class: 'form-control' %>
-      </p>
-    </div>
-    <div class="tab-pane fade" id="treatment-proposal" role="tabpanel" aria-labelledby="treatment-proposal-tab">
-      <p>
-        Proposal<br>
-        <%= f.text_area :treatment_proposal_proposal, class: 'form-control' %>
-      </p>
-
-      <p>
-        Housing Need<br>
-        <%= f.select(:treatment_proposal_housing_need_id, options_from_collection_for_select(@housing, "id", "key"), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
-      </p>
-
-      <p>
-        Factors Influencing Treatment<br>
-        <%= f.text_area :treatment_proposal_factors_influencing_treatment, class: 'form-control' %>
-      </p>
-
-      <p>
-        Performed Treatment<br>
-        <%= f.text_area :treatment_proposal_performed_treatment, class: 'form-control' %>
-      </p>
-
-      <p>
-        Housing Provided<br>
-        <%= f.select(:treatment_proposal_housing_provided_id, options_from_collection_for_select(@housing, "id", "key"), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
-      </p>
-
-      <p>
-        Housing Narrative<br>
-        <%= f.text_area :treatment_proposal_housing_narrative, class: 'form-control' %>
-      </p>
-
-      <p>
-        Storage and Handling Notes<br>
-        <%= f.text_area :treatment_proposal_storage_and_handling_notes, class: 'form-control' %>
-      </p>
-
-      <p>
-        Total Treatment Time<br>
-        <%= f.number_field :treatment_proposal_total_treatment_time, class: 'form-control' %>
-      </p>
-
-    </div>
+  <div class="tab-content" id="reportTabContent">
+    <div class="tab-pane fade show active" id="treatment-report" role="tabpanel" aria-labelledby="nav-home-tab"><%= render 'treatment_reports/form' %></div>
+    <div class="tab-pane fade" id="conservators-note" role="tabpanel" aria-labelledby="conservators-note"><%= render 'treatment_reports/conservators_note_form' %></div>
   </div>
-    
-    
-      <p>
-        <%= f.submit 'Save Treatment Report', class: 'btn btn-primary' %>
-      </p>
-    </div>
-    <% end %>
-</div>
-<br />
+
+
+  
 
 <div class="modal fade" id="inHouseRepairModal" tabindex="-1" role="dialog" aria-labelledby="inHouseRepairModal" aria-hidden="true">
   <div class="modal-dialog" role="document">

--- a/app/views/treatment_reports/_conservators_note_form.html.erb
+++ b/app/views/treatment_reports/_conservators_note_form.html.erb
@@ -1,0 +1,17 @@
+<br>
+<div class="header">
+  <h3>Conservator's Note</h3>
+  <a href="#">Download Abbreviated Treatment Report</a>
+</div>
+
+  <%= form_with(model: [@conservation_record, @conservation_record.treatment_report], class: 'disable_input') do |f| %>
+    <div class="form-group">
+      <p>
+        <%= f.text_area :conservators_note, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.submit 'Save Conservator Note', class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/treatment_reports/_form.html.erb
+++ b/app/views/treatment_reports/_form.html.erb
@@ -1,0 +1,161 @@
+<br>
+<div class="header">
+  <h3>Treatment Report</h3>
+  <!-- Currently just stubbing at the moment. -->
+  <%= link_to 'Download Treatment Report', treatment_report_path(@conservation_record), target: '_blank' %>
+</div>
+<br>
+<ul class="nav nav-tabs" id="myTab" role="tablist">
+  <li class="nav-item">
+    <a class="nav-link active" id="description-tab" data-toggle="tab" href="#description" role="tab" aria-controls="description" aria-selected="true">Description</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" id="condition-tab" data-toggle="tab" href="#condition" role="tab" aria-controls="condition" aria-selected="false">Condition</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" id="treatment-proposal-tab" data-toggle="tab" href="#treatment-proposal" role="tab" aria-controls="treatment-proposal" aria-selected="false">Treatment Proposal</a>
+  </li>
+</ul>
+
+<%= form_with(model: [@conservation_record, @conservation_record.treatment_report], class: 'disable_input') do |f| %>
+<div class="tab-content" id="myTabContent">
+  <div class="tab-pane fade show active" id="description" role="tabpanel" aria-labelledby="description-tab">
+    <div class="form-group">
+      <p>
+        General Remarks<br>
+        <%= f.text_area :description_general_remarks, class: 'form-control' %>
+      </p>
+
+      <p>
+        Binding<br>
+        <%= f.text_area :description_binding, class: 'form-control' %>
+      </p>
+
+      <p>
+        Textblock<br>
+        <%= f.text_area :description_textblock, class: 'form-control' %>
+      </p>
+
+      <p>
+        Primary Support<br>
+        <%= f.text_area :description_primary_support, class: 'form-control' %>
+      </p>
+
+      <p>
+        Medium<br>
+        <%= f.text_area :description_medium, class: 'form-control' %>
+      </p>
+
+      <p>
+        Attachments | Inserts<br>
+        <%= f.text_area :description_attachments_inserts, class: 'form-control' %>
+      </p>
+
+      <p>
+        Housing<br>
+        <%= f.text_area :description_housing, class: 'form-control' %>
+      </p>
+    </div>
+  </div>
+  <div class="tab-pane fade" id="condition" role="tabpanel" aria-labelledby="condition-tab">
+    <p>
+      Summary<br>
+      <%= f.text_area :condition_summary, class: 'form-control' %>
+    </p>
+
+    <p>
+      Binding<br>
+      <%= f.text_area :condition_binding, class: 'form-control' %>
+    </p>
+
+    <p>
+      Textblock<br>
+      <%= f.text_area :condition_textblock, class: 'form-control' %>
+    </p>
+
+    <p>
+      Primary Support<br>
+      <%= f.text_area :condition_primary_support, class: 'form-control' %>
+    </p>
+
+    <p>
+      Medium<br>
+      <%= f.text_area :condition_medium, class: 'form-control' %>
+    </p>
+
+    <p>
+      Housing<br>
+      <%= f.select(:condition_housing_id, options_from_collection_for_select(@housing, "id", "key"), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
+    </p>
+
+    <p>
+      Housing Narrative<br>
+      <%= f.text_area :condition_housing_narrative, class: 'form-control' %>
+    </p>
+
+    <p>
+      Attachments | Inserts<br>
+      <%= f.text_area :condition_attachments_inserts, class: 'form-control' %>
+    </p>
+
+    <p>
+      Previous Treatment<br>
+      <%= f.text_area :condition_previous_treatment, class: 'form-control' %>
+    </p>
+
+    <p>
+      Materials Analysis<br>
+      <%= f.text_area :condition_materials_analysis, class: 'form-control' %>
+    </p>
+  </div>
+  <div class="tab-pane fade" id="treatment-proposal" role="tabpanel" aria-labelledby="treatment-proposal-tab">
+    <p>
+      Proposal<br>
+      <%= f.text_area :treatment_proposal_proposal, class: 'form-control' %>
+    </p>
+
+    <p>
+      Housing Need<br>
+      <%= f.select(:treatment_proposal_housing_need_id, options_from_collection_for_select(@housing, "id", "key"), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
+    </p>
+
+    <p>
+      Factors Influencing Treatment<br>
+      <%= f.text_area :treatment_proposal_factors_influencing_treatment, class: 'form-control' %>
+    </p>
+
+    <p>
+      Performed Treatment<br>
+      <%= f.text_area :treatment_proposal_performed_treatment, class: 'form-control' %>
+    </p>
+
+    <p>
+      Housing Provided<br>
+      <%= f.select(:treatment_proposal_housing_provided_id, options_from_collection_for_select(@housing, "id", "key"), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
+    </p>
+
+    <p>
+      Housing Narrative<br>
+      <%= f.text_area :treatment_proposal_housing_narrative, class: 'form-control' %>
+    </p>
+
+    <p>
+      Storage and Handling Notes<br>
+      <%= f.text_area :treatment_proposal_storage_and_handling_notes, class: 'form-control' %>
+    </p>
+
+    <p>
+      Total Treatment Time<br>
+      <%= f.number_field :treatment_proposal_total_treatment_time, class: 'form-control' %>
+    </p>
+
+  </div>
+</div>
+
+
+<p>
+  <%= f.submit 'Save Treatment Report', class: 'btn btn-primary' %>
+</p>
+
+<% end %>
+<br />

--- a/db/migrate/20200320134630_add_conservators_note_to_treatment_report.rb
+++ b/db/migrate/20200320134630_add_conservators_note_to_treatment_report.rb
@@ -1,0 +1,5 @@
+class AddConservatorsNoteToTreatmentReport < ActiveRecord::Migration[5.2]
+  def change
+    add_column :treatment_reports, :conservators_note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_24_174713) do
+ActiveRecord::Schema.define(version: 2020_03_20_134630) do
 
   create_table "conservation_records", force: :cascade do |t|
     t.date "date_recieved_in_preservation_services"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2020_01_24_174713) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "conservation_record_id"
+    t.string "conservators_note"
     t.index ["conservation_record_id"], name: "index_treatment_reports_on_conservation_record_id"
   end
 

--- a/spec/controllers/treatment_reports_controller_spec.rb
+++ b/spec/controllers/treatment_reports_controller_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe TreatmentReportsController, type: :controller do
       treatment_proposal_housing_provided_id: housing_a.id,
       treatment_proposal_housing_narrative: 'Treatment Propsal Housing Narrative',
       treatment_proposal_storage_and_handling_notes: 'Treatment Proposal Storage Handling and Notes',
-      treatment_proposal_total_treatment_time: 30
+      treatment_proposal_total_treatment_time: 30,
+      conservators_report: "Conservator's Note"
     }
   end
 


### PR DESCRIPTION
fixes #76 

This PR adds a form for the conservators note, I think the best way to do this is to add a field on the treatment report model.

Additionally, I moved treatment report related forms into partials, I think I should do this with the other elements on this page but should likely open a new issue for that kind of refactor.

I've started noticing that one of my specs in this project is failing because of a non-unique key error, this is addressed in another PR.  In the mean time running `rake db:reset` and then running the specs seems to work.