### PR TITLE
Add webdrivers gem for js specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :development, :test do
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 3.8'
   gem 'rubocop-rails'
+  gem 'webdrivers', '~>4.0'
 end
 
 group :development do
@@ -85,7 +86,6 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.1)
     autoprefixer-rails (10.1.0.0)
@@ -70,9 +68,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -113,7 +108,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.1)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -234,7 +228,7 @@ GEM
       rubocop (>= 0.90.0, < 2.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (2.3.0)
+    rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -297,6 +291,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.5.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -313,7 +311,6 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  chromedriver-helper
   coffee-rails (~> 4.2)
   coveralls (~> 0.8.22)
   database_cleaner
@@ -345,6 +342,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   wkhtmltopdf-binary
 
 RUBY VERSION


### PR DESCRIPTION
Add https://github.com/titusfortner/webdrivers gem for js specs. For some reason, rspec can't seem to find the driver when the gem is isolated to the test group in the Gemfile; added to dev and test resolves this issue.