### PR TITLE
resolve failing specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,4 +66,5 @@ RSpec.configure do |config|
   Rails.application.load_seed
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe 'conservation_records/index', type: :view do
            ])
   end
 
-  after(:all) do
-    ConservationRecord.all.delete_all
-  end
-
   it 'renders a list of conservation_records' do
     @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
     render


### PR DESCRIPTION
Resolves #150 

Ran `rspec --bisect` and revealed a line in the specs was clearing the database. When run in random order, this resulted in unreliable db state. Also added :request devise integation helper to rails_helper.rb