### PR TITLE
fix uniq constraint failure in spec

### DIFF
--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'conservation_records/index', type: :view do
   include Devise::Test::ControllerHelpers
   include Pagy::Backend
 
-  before(:each) do
+  before do
     assign(:conservation_records, [
              ConservationRecord.create!(
                id: 200,


### PR DESCRIPTION
conservation_records#index view spec was throwing failure for unique constraint because we were creating a test record with set id before *each* example. Backed off to just once for all tests and this passes now.