### PR TITLE
resolve mass-assignment warning

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "c885cc05df4d2146d8452ec9809d902182d4e29e7e239b442ecf37b1a8939939",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/users_controller.rb",
+      "line": 37,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:user).permit(:id, :display_name, :email, :role, :account_active, :password, :password_confirmation)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "UsersController",
+        "method": "user_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "note": ""
+    }
+  ],
+  "updated": "2021-10-07 15:21:40 -0400",
+  "brakeman_version": "5.1.1"
+}


### PR DESCRIPTION
Resolves #185 

This :role param key is explicitly permitted to allow updates to by users with admin privileges. We can rely on the abilities validation to prevent unauthorized changes to the attribute.

Add mass assignment warning on :role key to brakeman.ignore file.

