### PR TITLE
Disable automatic gem update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: sunday
-    labels:
-      - dependencies
-      - bundler
-      - automated pr
-    target-branch: qa
-    reviewers:
-      - hortongn
-    assignees:
-      - hortongn
+  # Update gems
+  # - package-ecosystem: bundler
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
+  #     day: sunday
+  #  labels:
+  #    - dependencies
+  #    - bundler
+  #    - automated pr
+  #  target-branch: qa
+  #  reviewers:
+  #    - hortongn
+  #  assignees:
+  #    - hortongn
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Disables the automatic gem update PRs we receive on Sundays.  We will rely on bunder-audit for now.