### PR TITLE
Disable signup/edit for non-admin users

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,7 +46,6 @@ class Ability
     when 'read_only'
       can :view_pdfs, [ConservationRecord]
       can :read, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, StaffCode]
-      can :create_user, User
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 
   validates :display_name, :email, :role, presence: true

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -56,7 +56,6 @@
             <%= current_user.display_name %>
           </button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-            <%= link_to("Edit account", edit_user_registration_path, class: 'dropdown-item') %>
             <%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'dropdown-item') %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@
 Rails.application.routes.draw do
   resources :staff_codes
   post 'users', to: 'users#create_user'
-  # get 'reports', to: 'reports#index'
   resources :reports, only: [:index]
   devise_for :users, controllers: { registrations: 'users/registrations' }
   resources :users, controller: 'users', except: %i[create show]

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -18,15 +18,10 @@ RSpec.describe Users::RegistrationsController, type: :controller do
     before do
       sign_in user
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      put :update, params: { user: attr }
-      user.reload
     end
 
-    it { expect(response).to redirect_to(root_path) }
-    it { expect(flash[:notice]).to eq('Your account has been updated successfully.') }
-    it { expect(user.display_name).to eql attr[:display_name] }
-    it { expect(user.email).to eql attr[:email] }
-    it { expect(user.role).to eql attr[:role] }
-    it { expect(user.account_active).to be attr[:account_active] }
+    it 'raises an error' do
+      expect { put :update, params: { user: attr } }.to raise_error ActionController::UrlGenerationError
+    end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -47,15 +47,6 @@ RSpec.describe UsersController, type: :controller do
       post :create_user, params: { user: valid_attributes.except!(:email) }, session: valid_session
       expect(response).to redirect_to(root_path)
     end
-
-    context 'with valid params when user is not admin' do
-      let(:user) { create(:user, role: 'read_only') }
-      it 'with valid params when user is not an admin' do
-        post :create_user, params: { user: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(conservation_records_path)
-        expect(flash[:notice]).to be_present
-      end
-    end
   end
 
   describe 'PUT update/:id' do

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).to have_link('Vocabularies')
       expect(rendered).to have_link('Users')
       expect(rendered).to have_link('Reports')
-      expect(rendered).to have_link('Edit account')
+      expect(rendered).not_to have_link('Edit account')
       expect(rendered).to have_link('Logout')
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).not_to have_link('Vocabularies')
       expect(rendered).not_to have_link('Users')
       expect(rendered).not_to have_link('Reports')
-      expect(rendered).to have_link('Edit account')
+      expect(rendered).not_to have_link('Edit account')
       expect(rendered).to have_link('Logout')
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       expect(rendered).not_to have_link('Vocabularies')
       expect(rendered).not_to have_link('Users')
       expect(rendered).not_to have_link('Reports')
-      expect(rendered).to have_link('Edit account')
+      expect(rendered).not_to have_link('Edit account')
       expect(rendered).to have_link('Logout')
     end
   end


### PR DESCRIPTION
Resolves #319 

Remove :registerable module from devise to disable self-service signup and editing for user accounts. Users can still update their own passwords.