### PR TITLE
Capistrano fixes

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -17,4 +17,3 @@ task :use_rvm do
 end
 
 task local: :use_rvm
-# task qa: :use_rvm

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'brakeman', '~> 5.1', '>= 5.1.1'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'capistrano'
+  gem 'capistrano', '3.11.2'
   gem 'capistrano-bundler', '~> 1.6', require: false
   gem 'capistrano-rails', '~> 1.4', require: false
   gem 'capistrano-rvm', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrussh (1.4.0)
+    airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (9.0.0)
     ast (2.4.2)
@@ -65,7 +65,7 @@ GEM
       thor (~> 1.0)
     byebug (11.1.3)
     cancancan (3.4.0)
-    capistrano (3.17.0)
+    capistrano (3.11.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -356,7 +356,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   cancancan
-  capistrano
+  capistrano (= 3.11.2)
   capistrano-bundler (~> 1.6)
   capistrano-rails (~> 1.4)
   capistrano-rvm

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,7 +16,7 @@ end
 
 task :start_local do
   on roles(:all) do
-    execute "export PATH=$PATH:/usr/local/bin && cd #{fetch(:deploy_to)}/current/scripts && source start_local.sh"
+    execute "export PATH=$PATH:/usr/local/bin && cd #{fetch(:release_path)}/scripts && source start_local.sh"
     execute "mkdir -p #{fetch(:deploy_to)}/static"
   end
 end
@@ -32,12 +32,12 @@ end
 
 task :start_qp do
   on roles(:all) do
-    execute "cd #{fetch(:deploy_to)}/current && chmod a+x scripts/* && source scripts/start_qp.sh"
+    execute "cd #{fetch(:release_path)}/ && chmod a+x scripts/* && source scripts/start_qp.sh"
   end
 end
 
 task :ruby_update_check do
   on roles(:all) do
-    execute "cd #{fetch(:deploy_to)}/current && chmod a+x scripts/* && source scripts/check_ruby.sh"
+    execute "cd #{fetch(:release_path)}/ && chmod a+x scripts/* && source scripts/check_ruby.sh"
   end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,5 +10,6 @@ ask(:username, nil)
 ask(:password, nil, echo: false)
 server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22, roles: %i[web app db]
 set :deploy_to, '/opt/webapps/treatment_database'
+after 'deploy:updating', 'ruby_update_check'
 after 'deploy:updating', 'init_qp'
 before 'deploy:cleanup', 'start_qp'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,7 +2,7 @@
 
 set :rails_env, :production
 set :bundle_without, %w[development test].join(' ')
-set :branch, '281/capistrano'
+set :branch, '325/capistrano-fixes'
 set :default_env, path: '$PATH:/usr/local/bin'
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, '.bundle', 'tmp', 'log'

--- a/scripts/check_ruby.sh
+++ b/scripts/check_ruby.sh
@@ -1,10 +1,8 @@
-#!/bin/bash
-# Note: Change this to be the version on ruby needed on the server.
-# Could change this to read the .ruby-version in the project
-RUBY_VERSION=2.7.5
+!/bin/bash
+RUBY_VERSION=$(cat .ruby-version | sed s/ruby-//)
 
 if rbenv versions | grep -q $RUBY_VERSION; then
     echo 'Ruby' $RUBY_VERSION 'is installed'
 else
-    rbenv install $RUBY_VERSION
+    RUBY_CONFIGURE_OPTS="--disable-dtrace" rbenv install $RUBY_VERSION
 fi


### PR DESCRIPTION
- Pin Capistrano Version to 3.11.2
- Fix use of scripts in current (change to use from the latest pull)
- Update ruby check script to use the disable dtrace
- Change qa deploy to use qa branch by default