### PR TITLE
Stop logging treatment-record:create in paper_trail

### DIFF
--- a/app/models/treatment_report.rb
+++ b/app/models/treatment_report.rb
@@ -3,5 +3,5 @@
 class TreatmentReport < ApplicationRecord
   belongs_to :conservation_record
 
-  has_paper_trail
+  has_paper_trail on: %i[update destroy]
 end

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe 'Admin User Tests', type: :feature do
     expect(page).to have_content('Haritha Vytla deleted the external repair record')
     expect(page).to have_content('Haritha Vytla created the in house repair record')
     expect(page).to have_content('Haritha Vytla deleted the in house repair record')
-    expect(page).to have_content('Haritha Vytla created the treatment report')
+    expect(page).to_not have_content('Haritha Vytla created the treatment report')
     expect(page).to have_content('Haritha Vytla updated the treatment report')
   end
 end


### PR DESCRIPTION
Resolves #352 

Log only :update and :destroy actions for treatment-reports in paper_trail.

---

## Background

A TreatmentReport record with nil values is automatically created with a :before_action filter for ConservationRecords that don't have one attached. For ConservationRecords that were migrated without TreatmentReport data, any action on that record will create a TreatmentReport record and log the creation in the Activity Log.

Many of the Conservation Records do not have Treatment report records attached. The before_action filter to create and attach a Treatment Report is required by the form logic.

## Resolution:

Change paper_trail config to stop logging TreatmentReport record create actions. This suppresses a less meaningful log message and cleans up the logs.

