### PR TITLE
fix cutoff text in treatment pdf

### DIFF
--- a/app/views/conservation_records/treatment_report_pdf.html.erb
+++ b/app/views/conservation_records/treatment_report_pdf.html.erb
@@ -21,8 +21,9 @@ table {
   margin: 0 auto;
   display: table;
 }
+
 .tab {
-  display: inline-block; 
+  display: block; 
   margin-left: 40px; 
 }
 </style>


### PR DESCRIPTION
Resolves #362
<img width="1008" alt="Screen Shot 2023-02-01 at 2 45 55 PM" src="https://user-images.githubusercontent.com/1069588/216147314-1ca78e93-c484-4509-b8b3-754f91675160.png">
[A collection of 21 ledgers, binders and pamphlets from the cemetery_treatment_report-2.pdf](https://github.com/uclibs/treatment_database/files/10561065/A.collection.of.21.ledgers.binders.and.pamphlets.from.the.cemetery_treatment_report-2.pdf)
