### PR TITLE
Truncate pdf filenames

### DIFF
--- a/app/controllers/conservation_records_controller.rb
+++ b/app/controllers/conservation_records_controller.rb
@@ -77,20 +77,21 @@ class ConservationRecordsController < ApplicationController
     @conservation_record = ConservationRecord.find(params[:id])
     @base_64_form_image = "data:image/png;base64,#{Rails.public_path.join('worksheet_form_image.base64').read}"
 
-    send_data build_pdf('conservation_worksheet'), filename: "#{@conservation_record.title}_conservation_worksheet.pdf",
+    send_data build_pdf('conservation_worksheet'), filename: "#{@conservation_record.title.truncate(25, omission: '')}_conservation_worksheet.pdf",
                                                    type: 'application/pdf', disposition: 'inline'
   end
 
   def treatment_report
     @conservation_record = ConservationRecord.find(params[:id])
-    send_data build_pdf('treatment_report_pdf'), filename: "#{@conservation_record.title}_treatment_report.pdf",
+    send_data build_pdf('treatment_report_pdf'), filename: "#{@conservation_record.title.truncate(25, omission: '')}_treatment_report.pdf",
                                                  type: 'application/pdf', disposition: 'inline'
   end
 
   def abbreviated_treatment_report
     @conservation_record = ConservationRecord.find(params[:id])
-    send_data build_pdf('abbreviated_treatment_report_pdf'), filename: "#{@conservation_record.title}_abbreviated_treatment_report.pdf",
-                                                             type: 'application/pdf', disposition: 'inline'
+    send_data build_pdf('abbreviated_treatment_report_pdf'),
+              filename: "#{@conservation_record.title.truncate(25, omission: '')}_abbreviated_treatment_report.pdf",
+              type: 'application/pdf', disposition: 'inline'
   end
 
   def build_pdf(format)

--- a/spec/controllers/conservation_records_controller_spec.rb
+++ b/spec/controllers/conservation_records_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
     department_a = create(:controlled_vocabulary, vocabulary: 'department', key: 'Department A')
     {
       department: department_a.id,
-      title: 'Farewell to Arms',
+      title: 'Farewell to Arms and Legs and Eyes and Ears',
       author: 'A Good Writer',
       imprint: 'Dutton',
       call_number: 'P102.3294.3920',
@@ -189,6 +189,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
       conservation_record = ConservationRecord.create! valid_attributes
       get :conservation_worksheet, params: { id: conservation_record.id }
       expect(response.headers['Content-Type']).to eq('application/pdf')
+      expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_conservation_worksheet.pdf')
     end
 
     context 'with read_only user' do
@@ -197,10 +198,11 @@ RSpec.describe ConservationRecordsController, type: :controller do
         sign_in_user(read_user)
       end
 
-      it 'redirects to home with an error' do
+      it 'sends a file' do
         conservation_record = ConservationRecord.create! valid_attributes
         get :conservation_worksheet, params: { id: conservation_record.id }
         expect(response.headers['Content-Type']).to eq('application/pdf')
+        expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_conservation_worksheet.pdf')
       end
     end
 
@@ -214,6 +216,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
         conservation_record = ConservationRecord.create! valid_attributes
         get :conservation_worksheet, params: { id: conservation_record.id }
         expect(response.headers['Content-Type']).to eq('application/pdf')
+        expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_conservation_worksheet.pdf')
       end
     end
   end
@@ -223,6 +226,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
       conservation_record = ConservationRecord.create! valid_attributes
       get :treatment_report, params: { id: conservation_record.id }
       expect(response.headers['Content-Type']).to eq('application/pdf')
+      expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_treatment_report.pdf')
     end
 
     context 'with read_only user' do
@@ -235,6 +239,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
         conservation_record = ConservationRecord.create! valid_attributes
         get :treatment_report, params: { id: conservation_record.id }
         expect(response.headers['Content-Type']).to eq('application/pdf')
+        expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_treatment_report.pdf')
       end
     end
 
@@ -257,6 +262,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
       conservation_record = ConservationRecord.create! valid_attributes
       get :abbreviated_treatment_report, params: { id: conservation_record.id }
       expect(response.headers['Content-Type']).to eq('application/pdf')
+      expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_abbreviated_treatment_report.pdf')
     end
 
     context 'with read_only user' do
@@ -265,10 +271,11 @@ RSpec.describe ConservationRecordsController, type: :controller do
         sign_in_user(read_user)
       end
 
-      it 'redirects to home with an error' do
+      it 'sends a file' do
         conservation_record = ConservationRecord.create! valid_attributes
         get :abbreviated_treatment_report, params: { id: conservation_record.id }
         expect(response.headers['Content-Type']).to eq('application/pdf')
+        expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_abbreviated_treatment_report.pdf')
       end
     end
 
@@ -282,6 +289,7 @@ RSpec.describe ConservationRecordsController, type: :controller do
         conservation_record = ConservationRecord.create! valid_attributes
         get :abbreviated_treatment_report, params: { id: conservation_record.id }
         expect(response.headers['Content-Type']).to eq('application/pdf')
+        expect(response.headers['Content-Disposition']).to have_content('Farewell to Arms and Legs_abbreviated_treatment_report.pdf')
       end
     end
   end


### PR DESCRIPTION
Resolves #375 

Truncate titles to 25 characters before interpolating to PDF filenames.