### PR TITLE
Restrict access to activity log

### DIFF
--- a/app/controllers/activity_controller.rb
+++ b/app/controllers/activity_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ActivityController < ApplicationController
+  before_action :authenticate_user!
+  authorize_resource class: false
+
   def index
     @pagy, @versions = pagy(PaperTrail::Version.all, items: 50)
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,11 +38,9 @@ class Ability
     case user.role
     when 'admin'
       can :manage, :all
-      can :assign_roles, User
-      can :crud, [ControlledVocabulary, StaffCode]
     when 'standard'
       can :view_pdfs, ConservationRecord
-      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, ConTechRecord, StaffCode, CostReturnReport, Report]
+      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, ConTechRecord, StaffCode, CostReturnReport, Report, :activity]
     when 'read_only'
       can :view_pdfs, ConservationRecord
       can :read, ConservationRecord

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,6 +11,15 @@ describe 'User', type: :model do
     context 'when is an admin' do
       let(:user) { build(:user, role: 'admin') }
       it { is_expected.to be_able_to(:manage, User.new) }
+      it { is_expected.to be_able_to(:manage, ConservationRecord.new) }
+      it { is_expected.to be_able_to(:manage, ControlledVocabulary.new) }
+      it { is_expected.to be_able_to(:manage, ExternalRepairRecord.new) }
+      it { is_expected.to be_able_to(:manage, InHouseRepairRecord.new) }
+      it { is_expected.to be_able_to(:manage, StaffCode.new) }
+      it { is_expected.to be_able_to(:manage, CostReturnReport.new) }
+      it { is_expected.to be_able_to(:manage, ConTechRecord.new) }
+      it { is_expected.to be_able_to(:manage, Report.new) }
+      it { is_expected.to be_able_to(:manage, :activity) }
     end
 
     context 'when is a standard user' do
@@ -68,6 +77,9 @@ describe 'User', type: :model do
       it { is_expected.to be_able_to(:create, Report.new) }
       it { is_expected.to be_able_to(:read, Report.new) }
       it { is_expected.to be_able_to(:destroy, Report.new) }
+
+      it { is_expected.to be_able_to(:index, :activity) }
+      it { is_expected.to be_able_to(:show, :activity) }
     end
 
     context 'when is a read_only user' do
@@ -126,6 +138,9 @@ describe 'User', type: :model do
       it { is_expected.not_to be_able_to(:read, Report.new) }
       it { is_expected.not_to be_able_to(:update, Report.new) }
       it { is_expected.not_to be_able_to(:destroy, Report.new) }
+
+      it { is_expected.not_to be_able_to(:index, :activity) }
+      it { is_expected.not_to be_able_to(:show, :activity) }
     end
   end
 end


### PR DESCRIPTION
Resolves #408 

We use CanCan to authorize actions in the app and neglected to include the activity log in the abilities set. 

This PR restricts activity log access to standard and admin users using abilities model. 

Also fleshes out specs for admin abilities. 