### PR TITLE
Fix error preventing activity log diff

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    minitest (5.19.0)
+    minitest (5.20.0)
     msgpack (1.6.0)
     mysql2 (0.5.5)
     net-imap (0.3.7)
@@ -203,8 +203,8 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.0.1)
-    paper_trail (14.0.0)
-      activerecord (>= 6.0)
+    paper_trail (15.1.0)
+      activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
@@ -379,10 +379,11 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module TreatmentDatabase
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.active_job.queue_adapter = :inline
+    config.active_record.yaml_column_permitted_classes = [ActiveSupport::TimeWithZone, Time, ActiveSupport::TimeZone]
   end
 end

--- a/spec/controllers/activity_controller_spec.rb
+++ b/spec/controllers/activity_controller_spec.rb
@@ -41,10 +41,18 @@ RSpec.describe ActivityController, type: :controller do
   end
 
   describe 'GET #show' do
+    let(:conservation_record) { create(:conservation_record) }
+
     it 'returns a success response' do
       version = PaperTrail::Version.create! valid_attributes
       get :show, params: { id: version.to_param }
       expect(response).to be_successful
+    end
+
+    it 'returns change details', versioning: true do
+      conservation_record.update(title: 'The Oddysee')
+      changes = conservation_record.versions.last.changeset.reject { |k, _v| (k.to_sym == :updated_at) }
+      expect(changes).to(eq('title' => ['The Illiad', 'The Oddysee']))
     end
   end
 end

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Admin User Tests', type: :feature do
+RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
   let(:user) { create(:user, role: 'admin') }
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 2) }
@@ -77,7 +77,6 @@ RSpec.describe 'Admin User Tests', type: :feature do
     select('Admin', from: 'Role')
     click_on 'Update User'
     expect(page).to have_content('Haritha Vytla')
-
     # View Activity
 
     visit conservation_records_path

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   end
 end
 
-RSpec.describe 'Standard User Tests', type: :feature do
+RSpec.describe 'Standard User Tests', type: :feature, versioning: true do
   let(:user) { create(:user, role: 'standard') }
   let!(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
@@ -199,7 +199,7 @@ RSpec.describe 'Standard User Tests', type: :feature do
   end
 end
 
-RSpec.describe 'Admin User Tests', type: :feature do
+RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
   let(:user) { create(:user, role: 'admin') }
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
   let(:vocabulary) { create(:controlled_vocabulary) }
@@ -402,5 +402,17 @@ RSpec.describe 'Admin User Tests', type: :feature do
     expect(page).to have_content('Haritha Vytla deleted the in house repair record')
     expect(page).to_not have_content('Haritha Vytla created the treatment report')
     expect(page).to have_content('Haritha Vytla updated the treatment report')
+
+    # Check that details page shows diff data
+    visit conservation_records_path
+    click_link(conservation_record.title, match: :prefer_exact)
+    fill_in 'treatment_report_description_binding', with: 'Half leather tightjoint, tight back binding'
+    click_button('Save Treatment Report')
+    expect(page).to have_content('Treatment Record updated successfully!')
+    visit activity_index_path
+    expect(page).to have_content('Haritha Vytla updated the treatment report')
+    first('tr').click_link('Details')
+    expect(page).to have_content('Full leather tightjoint, tight back binding')
+    expect(page).to have_content('Half leather tightjoint, tight back binding')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'factory_bot'
 require 'rspec/rails'
+require 'paper_trail/frameworks/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Resolves #410

`@version.changeset` was returning an empty hash due to YAML serialization permitted class exceptions, restrictions introduced after an RCE escalation risk was discovered. Examining the deserializer in the paper_trail gem showed that we needed to allow `ActiveSupport::TimeWithZone, Time, ActiveSupport::TimeZone` classes for the changes to load.

Debug here: https://github.com/paper-trail-gem/paper_trail/blob/master/lib/paper_trail/version_concern.rb#L357

Related: https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017
And: https://stackoverflow.com/a/72970171

**Changes**
* Allow `ActiveSupport::TimeWithZone, Time, ActiveSupport::TimeZone` classes for yaml load in `config/application.rb`
* Add rspec helper class provided by PaperTrail
* Add controller test to activity controller to ensure that diff data is being populated to the changeset
* Add feature test to check for diff strings in activity details show page.
* Upgrade PaperTrail to v.15

Note that PaperTrail/versioning is now turned off for specs by default. To include versioning functionality in specs you need to activate in the test block.