### PR TITLE
Add conservators and technicians to version tracking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,8 +157,9 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.1)
+    i18n (1.14.3)
       concurrent-ruby (~> 1.0)
+      racc (~> 1.7)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -215,7 +216,7 @@ GEM
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (7.0.8)
+    pagy (7.0.9)
     paper_trail (15.1.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
@@ -296,7 +297,7 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.61.0)
+    rubocop (1.62.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -304,7 +305,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.1)
@@ -461,4 +462,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.3
+   2.5.6

--- a/app/models/con_tech_record.rb
+++ b/app/models/con_tech_record.rb
@@ -3,4 +3,6 @@
 class ConTechRecord < ApplicationRecord
   belongs_to :conservation_record
   validates :performed_by_user_id, presence: true
+
+  has_paper_trail
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load
+Dotenv::Rails.load
 
 module TreatmentDatabase
   class Application < Rails::Application

--- a/spec/models/con_tech_record_spec.rb
+++ b/spec/models/con_tech_record_spec.rb
@@ -22,4 +22,8 @@ RSpec.describe ConTechRecord, type: :model do
   it 'is not valid without a conservation record id' do
     expect(ConTechRecord.new(performed_by_user_id: 2)).to_not be_valid
   end
+
+  it 'is tracked by paper trail' do
+    is_expected.to be_versioned
+  end
 end

--- a/spec/models/conservation_record_spec.rb
+++ b/spec/models/conservation_record_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe ConservationRecord, type: :model do
     expect(ConservationRecord.new(department: '1', title: 'Some test title', author: 'Earnest Hemingway', imprint: 'Uc Press',
                                   call_number: 'PA2323')).to_not be_valid
   end
+
+  it 'is tracked by paper trail' do
+    is_expected.to be_versioned
+  end
 end

--- a/spec/models/external_repair_record_spec.rb
+++ b/spec/models/external_repair_record_spec.rb
@@ -22,4 +22,8 @@ RSpec.describe ExternalRepairRecord, type: :model do
     expect(ExternalRepairRecord.new(conservation_record_id: @conservation_record.id, performed_by_vendor_id: 2)).to_not be_valid
     expect(ExternalRepairRecord.new(performed_by_vendor_id: '1')).to_not be_valid
   end
+
+  it 'is tracked by paper trail' do
+    is_expected.to be_versioned
+  end
 end

--- a/spec/models/in_house_repair_record.rb
+++ b/spec/models/in_house_repair_record.rb
@@ -35,4 +35,8 @@ RSpec.describe InHouseRepairRecord, type: :model do
   it 'is not valid without a staff_code id' do
     expect(InHouseRepairRecord.new(conservation_record_id: @conservation_record.id, performed_by_user_id: 2, repair_type: 1)).to_not be_valid
   end
+
+  it 'is tracked by paper trail' do
+    is_expected.to be_versioned
+  end
 end

--- a/spec/models/treatment_report_spec.rb
+++ b/spec/models/treatment_report_spec.rb
@@ -3,5 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe TreatmentReport, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'is tracked by paper trail' do
+    is_expected.to be_versioned
+  end
 end


### PR DESCRIPTION
Resolves #431 

Add conservators_and_technicians to version tracking. Also add line to model specs to make sure the object is being tracked in versioning.