### PR TITLE
Include uncataloged id's in item record search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,7 @@ class SearchController < ApplicationController
   def results
     @search_string = params[:search]
     @records = case @search_string
-               when /^i\d{1,}/
+               when /^[a-zA-Z]+\d{1,}/
                  ConservationRecord.where(item_record_number: @search_string)
                when /^\d+$/
                  ConservationRecord.where(id: @search_string)

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SearchController, type: :controller do
     sign_in_user(user)
     create(:conservation_record)
     create(:conservation_record, item_record_number: 'i1001')
+    create(:conservation_record, item_record_number: 'notcat2817')
     create(:conservation_record, title: 'Third Title')
   end
 
@@ -26,6 +27,12 @@ RSpec.describe SearchController, type: :controller do
   it 'can search for documents by item record number' do
     get :results, params: { search: 'i1001' }
     expected_id = ConservationRecord.find_by(item_record_number: 'i1001').id
+    expect(response).to redirect_to(conservation_record_path(expected_id))
+  end
+
+  it 'can search for documents by *un-cataloged* record number' do
+    get :results, params: { search: 'notcat2817' }
+    expected_id = ConservationRecord.find_by(item_record_number: 'notcat2817').id
     expect(response).to redirect_to(conservation_record_path(expected_id))
   end
 


### PR DESCRIPTION
Resolves #418 

The search controller was using a restrictive regex to identify item record numbers in search strings, looking for precise pattern of a string initilized by a single lower-case "i", followed by a series of numeric characters. Not all records have these item-record numbers: those without are assigned an identifier initialized with 'notcat' and a series of numeric characters. Staff expected the "notcat" identifiers to be retrievable via search but results excluded these records. 

To fix, we edit the regex patter for item-record retrieval to include any initial alpha character series followed by digits. This will return results with identifiers initialized with "i", "notcat" and any other series of alpha characters followed by numeric characters.