### PR TITLE
Add favorite:boolean to controlled vocab

### DIFF
--- a/app/controllers/conservation_records_controller.rb
+++ b/app/controllers/conservation_records_controller.rb
@@ -17,9 +17,9 @@ class ConservationRecordsController < ApplicationController
   # GET /conservation_records/1.json
   def show
     @users = User.all
-    @repair_types = ControlledVocabulary.where(vocabulary: 'repair_type', active: true)
-    @contract_conservators = ControlledVocabulary.where(vocabulary: 'contract_conservator', active: true)
-    @housing = ControlledVocabulary.where(vocabulary: 'housing', active: true)
+    @repair_types = ControlledVocabulary.where(vocabulary: 'repair_type', active: true).order(favorite: :desc)
+    @contract_conservators = ControlledVocabulary.where(vocabulary: 'contract_conservator', active: true).order(favorite: :desc)
+    @housing = ControlledVocabulary.where(vocabulary: 'housing', active: true).order(favorite: :desc)
     @in_house_repairs = @conservation_record.in_house_repair_records
     @external_repairs = @conservation_record.external_repair_records
     @con_tech_records = @conservation_record.con_tech_records
@@ -125,7 +125,7 @@ class ConservationRecordsController < ApplicationController
   end
 
   def set_departments
-    @departments = ControlledVocabulary.where(vocabulary: 'department', active: true)
+    @departments = ControlledVocabulary.where(vocabulary: 'department', active: true).order(favorite: :desc)
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/controlled_vocabularies_controller.rb
+++ b/app/controllers/controlled_vocabularies_controller.rb
@@ -62,6 +62,6 @@ class ControlledVocabulariesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def controlled_vocabulary_params
-    params.require(:controlled_vocabulary).permit(:vocabulary, :key, :active)
+    params.require(:controlled_vocabulary).permit(:vocabulary, :key, :active, :favorite)
   end
 end

--- a/app/views/controlled_vocabularies/_controlled_vocabulary.json.jbuilder
+++ b/app/views/controlled_vocabularies/_controlled_vocabulary.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! controlled_vocabulary, :id, :vocabulary, :key, :active, :created_at, :updated_at
+json.extract! controlled_vocabulary, :id, :vocabulary, :key, :active, :favorite, :created_at, :updated_at
 json.url controlled_vocabulary_url(controlled_vocabulary, format: :json)

--- a/app/views/controlled_vocabularies/_form.html.erb
+++ b/app/views/controlled_vocabularies/_form.html.erb
@@ -27,6 +27,12 @@
     <%= form.check_box :active,class: 'btn btn-primary' %>
   </div>
 
+  <div class="form-group">
+    <%= form.label :favorite %>
+    <%= form.check_box :favorite,class: 'btn btn-primary' %>
+  </div>
+
+
   <div class="actions">
     <%= form.submit class: 'btn btn-primary'%>
   </div>

--- a/app/views/controlled_vocabularies/index.html.erb
+++ b/app/views/controlled_vocabularies/index.html.erb
@@ -14,6 +14,7 @@
       <th>Vocabulary</th>
       <th>Key</th>
       <th>Active</th>
+      <th>Favorite</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -24,6 +25,7 @@
         <td><%= controlled_vocabulary.vocabulary %></td>
         <td><%= link_to controlled_vocabulary.key, controlled_vocabulary %></td>
         <td><%= controlled_vocabulary.active %></td>
+        <td><%= controlled_vocabulary.favorite %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/controlled_vocabularies/show.html.erb
+++ b/app/views/controlled_vocabularies/show.html.erb
@@ -14,5 +14,11 @@
   <strong>Active:</strong>
   <%= @controlled_vocabulary.active %>
 </p>
+
+<p>
+  <strong>Favorite:</strong>
+  <%= @controlled_vocabulary.favorite %>
+</p>
+
 <%= link_to 'Edit', edit_controlled_vocabulary_path(@controlled_vocabulary) %> |
 <%= link_to 'Return to List', controlled_vocabularies_path %>

--- a/db/migrate/20240307145522_add_favorite_to_controlled_vocabulary.rb
+++ b/db/migrate/20240307145522_add_favorite_to_controlled_vocabulary.rb
@@ -1,0 +1,5 @@
+class AddFavoriteToControlledVocabulary < ActiveRecord::Migration[6.1]
+  def change
+    add_column :controlled_vocabularies, :favorite, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_05_164303) do
+ActiveRecord::Schema.define(version: 2024_03_07_145522) do
 
   create_table "abbreviated_treatment_reports", force: :cascade do |t|
     t.integer "conservation_record_id"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2023_04_05_164303) do
     t.boolean "active"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "favorite", default: false
   end
 
   create_table "cost_return_reports", force: :cascade do |t|

--- a/spec/controllers/conservation_records_controller_spec.rb
+++ b/spec/controllers/conservation_records_controller_spec.rb
@@ -91,6 +91,38 @@ RSpec.describe ConservationRecordsController, type: :controller do
       get :show, params: { id: conservation_record.to_param }
       expect(response).to be_successful
     end
+
+    it 'returns repair_types select options ordered by favorites' do
+      term = ControlledVocabulary.find_by(key: 'Training')
+      term.update(favorite: true)
+      conservation_record = ConservationRecord.create! valid_attributes
+      get :show, params: { id: conservation_record.to_param }
+      expect(controller.view_assigns['repair_types']).to start_with(term)
+    end
+
+    it 'returns housing select options ordered by favorites' do
+      term = ControlledVocabulary.find_by(key: 'Tuxedo Box')
+      term.update(favorite: true)
+      conservation_record = ConservationRecord.create! valid_attributes
+      get :show, params: { id: conservation_record.to_param }
+      expect(controller.view_assigns['housing']).to start_with(term)
+    end
+
+    it 'returns contract_conservators select options ordered by favorites' do
+      term = ControlledVocabulary.find_by(key: 'Richard Baker')
+      term.update(favorite: true)
+      conservation_record = ConservationRecord.create! valid_attributes
+      get :show, params: { id: conservation_record.to_param }
+      expect(controller.view_assigns['contract_conservators']).to start_with(term)
+    end
+
+    it 'returns departments select options ordered by favorites' do
+      term = ControlledVocabulary.find_by(key: 'Chem-Bio Library')
+      term.update(favorite: true)
+      conservation_record = ConservationRecord.create! valid_attributes
+      get :show, params: { id: conservation_record.to_param }
+      expect(controller.view_assigns['departments']).to start_with(term)
+    end
   end
 
   describe 'GET #new' do

--- a/spec/controllers/controlled_vocabularies_controller_spec.rb
+++ b/spec/controllers/controlled_vocabularies_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ControlledVocabulariesController, type: :controller do
   # ControlledVocabulary. As you add validations to ControlledVocabulary, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) do
-    { vocabulary: 'repair_type', key: 'Wash', active: true }
+    { vocabulary: 'repair_type', key: 'Wash', active: true, favorite: true }
   end
 
   let(:invalid_attributes) do
@@ -119,7 +119,7 @@ RSpec.describe ControlledVocabulariesController, type: :controller do
   describe 'PUT #update' do
     context 'with valid params' do
       let(:new_attributes) do
-        { vocabulary: 'something', key: 'else', active: false }
+        { vocabulary: 'something', key: 'else', active: false, favorite: true }
       end
 
       it 'updates the requested controlled_vocabulary' do
@@ -129,6 +129,7 @@ RSpec.describe ControlledVocabulariesController, type: :controller do
         expect(controlled_vocabulary.vocabulary).to eq('something')
         expect(controlled_vocabulary.key).to eq('else')
         expect(controlled_vocabulary.active).to eq(false)
+        expect(controlled_vocabulary.favorite).to eq(true)
       end
 
       it 'redirects to the controlled_vocabulary' do

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -268,6 +268,7 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     select 'repair_type', from: 'Vocabulary'
     fill_in 'Key', with: 'key_string'
     check 'Active'
+    check 'Favorite'
     click_button 'Create Controlled vocabulary'
 
     expect(page).to have_content('Controlled vocabulary was successfully created')
@@ -307,6 +308,9 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_button('Add In-House Repairs')
     click_button('Add In-House Repairs')
     select('Haritha Vytla', from: 'in_house_repair_record_performed_by_user_id', match: :first)
+    # get list of repair_types and check that favorite is first option
+    repair_types = find('#in_house_repair_record_repair_type').all('option').collect(&:text)
+    expect(repair_types[1..]).to start_with('updated_key_string')
     select('Mend paper', from: 'in_house_repair_record_repair_type', match: :first)
     fill_in('in_house_repair_record_other_note', with: 'Some Other note for the in-house repair')
     fill_in('in_house_repair_record_minutes_spent', with: '2')

--- a/spec/views/controlled_vocabularies/edit.html.erb_spec.rb
+++ b/spec/views/controlled_vocabularies/edit.html.erb_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'controlled_vocabularies/edit', type: :view do
       assert_select 'input[name=?]', 'controlled_vocabulary[key]'
 
       assert_select 'input[name=?]', 'controlled_vocabulary[active]'
+
+      assert_select 'input[name=?]', 'controlled_vocabulary[favorite]'
     end
   end
 end

--- a/spec/views/controlled_vocabularies/index.html.erb_spec.rb
+++ b/spec/views/controlled_vocabularies/index.html.erb_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe 'controlled_vocabularies/index', type: :view do
              ControlledVocabulary.create!(
                vocabulary: 'Vocabulary',
                key: 'Key',
-               active: false
+               active: false,
+               favorite: true
              ),
              ControlledVocabulary.create!(
                vocabulary: 'Vocabulary',
                key: 'Key',
-               active: false
+               active: false,
+               favorite: true
              )
            ])
   end
@@ -25,6 +27,7 @@ RSpec.describe 'controlled_vocabularies/index', type: :view do
     assert_select 'tr>td', text: 'Vocabulary'.to_s, count: 2
     assert_select 'tr>td', text: 'Key'.to_s, count: 2
     assert_select 'tr>td', text: false.to_s, count: 2
+    assert_select 'tr>td', text: true.to_s, count: 2
     expect(rendered).to have_link('Key')
   end
 end

--- a/spec/views/controlled_vocabularies/new.html.erb_spec.rb
+++ b/spec/views/controlled_vocabularies/new.html.erb_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'controlled_vocabularies/new', type: :view do
       assert_select 'input[name=?]', 'controlled_vocabulary[key]'
 
       assert_select 'input[name=?]', 'controlled_vocabulary[active]'
+
+      assert_select 'input[name=?]', 'controlled_vocabulary[favorite]'
     end
   end
 end

--- a/spec/views/controlled_vocabularies/show.html.erb_spec.rb
+++ b/spec/views/controlled_vocabularies/show.html.erb_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'controlled_vocabularies/show', type: :view do
     @controlled_vocabulary = assign(:controlled_vocabulary, ControlledVocabulary.create!(
                                                               vocabulary: 'Vocabulary',
                                                               key: 'Key',
-                                                              active: false
+                                                              active: false,
+                                                              favorite: true
                                                             ))
   end
 
@@ -16,5 +17,6 @@ RSpec.describe 'controlled_vocabularies/show', type: :view do
     expect(rendered).to match(/Vocabulary/)
     expect(rendered).to match(/Key/)
     expect(rendered).to match(/false/)
+    expect(rendered).to match(/true/)
   end
 end


### PR DESCRIPTION
Resolves #428 

Add favorite:boolean variable to the ControlledVocabulary object along with view components to edit and display. Add sort to @repair_type which feeds the Repair Type form drop-downs, so that vocab terms marked as favorite will sort to top of select options.

This allows admin to choose repair type terms that should sort to top of options. The sort has only been applied to repair types but could be applied to other controlled vocab select menus. 

I should note that in the issue, preservation staff requested a specific order for repair types. I think this is a compromise that allows them to control priority of the terms without the rigidity of hard-coding the order. The trade-off is a lack of precision. 

We should check with Preservation staff to confirm if this solution is acceptable. 