### PR TITLE
Add conservators & technicians to full treatment report

### DIFF
--- a/app/views/conservation_records/treatment_report_pdf.html.erb
+++ b/app/views/conservation_records/treatment_report_pdf.html.erb
@@ -26,6 +26,10 @@ table {
   display: block; 
   margin-left: 40px; 
 }
+
+ul {
+list-style: none;
+}
 </style>
 <div class="a4">
   <div class="banner section">
@@ -37,19 +41,17 @@ table {
       <tr>
         <th>Database ID</th>
         <th>Item Record #</th>
-	<th>Date Received in Pres.</th>
-	<th>Conservator</th>
+      	<th>Date Received in Pres.</th>
+      	<th>Conservators &amp; Technicians</th>
       </tr>
       <tr>
         <td><%= @conservation_record.id %></td>
         <td><%= @conservation_record.item_record_number %></td>
         <td><%= @conservation_record.date_received_in_preservation_services %></td>
+        <td>
+          <%= @conservation_record.con_tech_records.map { |name| generate_con_tech_string(name, nil) }.join(', ').html_safe %>
+        </td>
       </tr>
-      <tr><td><br></td></tr>
-      <tr>
-	<th>Technicians</th>
-      </tr>
-      <tr><td><br></td></tr>
       <tr>
 	<th>Department</th>
 	<th>Call Number</th>

--- a/spec/views/conservation_records/treatment_report_pdf.erb_spec.rb
+++ b/spec/views/conservation_records/treatment_report_pdf.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'conservation_records/treatment_report_pdf', type: :view do
     assign(:conservation_record, create(:conservation_record, department: department_id))
     conservation_record_id = ConservationRecord.last.id
     assign(:treatment_report, create(:treatment_report, conservation_record_id:))
+    assign(:con_tech_record1, create(:con_tech_record, performed_by_user_id: User.last.id, conservation_record_id:))
   end
 
   it 'renders new treatment_report_pdf form' do
@@ -18,6 +19,8 @@ RSpec.describe 'conservation_records/treatment_report_pdf', type: :view do
     expect(rendered).to have_content('James Joyce')
     expect(rendered).to have_content('i3445')
     expect(rendered).to have_content('102340')
+    expect(rendered).to have_content('102340')
+    expect(rendered).to have_content(User.last.display_name)
     headers = ['DESCRIPTION', 'CONDITION', 'TREATMENT', 'PRODUCTION - WORK ASSIGNMENT AND TIME', 'TOTAL Treatment and Documentation Time']
     headers.each do |header|
       expect(rendered).to have_content(header)


### PR DESCRIPTION
Resolves #430 

Conservators and technicians were missing from the full treatment report. Add them with a spec. 

Ex: [Farewell to Arms_treatment_report.pdf](https://github.com/uclibs/treatment_database/files/14937256/Farewell.to.Arms_treatment_report.pdf)
