### PR TITLE
MERGE TO FEATURE BRANCH 214 : Update Rails Helper

### DIFF
--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     visit conservation_records_path
     click_on 'New Conservation Record'
     expect(page).to have_content('New Conservation Record')
+    fill_in 'Date received in preservation services', with: '04/15/2024'
     select('ARB Library', from: 'Department', match: :first)
     fill_in 'Title', with: conservation_record.title
     fill_in 'Author', with: conservation_record.author

--- a/spec/features/read_only_user_spec.rb
+++ b/spec/features/read_only_user_spec.rb
@@ -2,18 +2,6 @@
 
 require 'rails_helper'
 
-require 'capybara'
-
-Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
-  browser_options = Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--no-sandbox'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless_sandboxless
-
 RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   let(:user) { create(:user, role: 'read_only') }
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 'ARB Library') }

--- a/spec/features/specs/user_scenarios/admin_user_spec.rb
+++ b/spec/features/specs/user_scenarios/admin_user_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# admin_user_spec.rb is dedicated to testing the functionalities
+# and permissions unique to administrative users within the application.
+# This spec file assesses the ability of admin users to access and
+# interact with administrative-specific features, such as user and settings
+# management. It ensures that all administrative actions are secured and
+# function correctly, reflecting the critical role of admins in maintaining
+# the system. It checks that these users can perform their tasks without
+# encountering unauthorized access errors or other barriers.

--- a/spec/features/specs/user_scenarios/non_authenticated_user_spec.rb
+++ b/spec/features/specs/user_scenarios/non_authenticated_user_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# non_authenticated_user_spec.rb focuses on the behavior of the
+# application when accessed by users who are not logged in. The primary
+# purpose of this spec is to ensure that non-authenticated users are
+# correctly redirected to the login screen and that they do not have
+# access to any application functionalities beyond this point. This
+# file plays a crucial role in securing the application by verifying
+# that proper access controls are in place, preventing unauthorized
+# access to sensitive data and features. Tests within this file
+# confirm the robustness of the application's authentication gates.

--- a/spec/features/specs/user_scenarios/read_only_user_spec.rb
+++ b/spec/features/specs/user_scenarios/read_only_user_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# read_only_user_spec.rb tests the application from the perspective
+# of users with read-only access. It verifies that these users can view
+# documents and data as expected but are restricted from creating,
+# editing, or deleting any records. This spec ensures that the application
+# enforces these permissions correctly, crucial for maintaining data
+# integrity and security. By confirming that read-only users cannot
+# perform unauthorized actions, this spec helps safeguard the application
+# against potential data manipulation or accidental changes by users without
+# adequate privileges.

--- a/spec/features/specs/user_scenarios/standard_user_spec.rb
+++ b/spec/features/specs/user_scenarios/standard_user_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# standard_user_spec.rb evaluates the application's functionality for standard
+# users, who have permissions to create, view, edit, and delete records within
+# their scope of access. This spec file tests the core functionalities
+# accessible to most users, ensuring they operate as intended. It's crucial
+# for verifying that standard users experience the application correctly,
+# with all intended functionalities available and working properly. These tests
+# help maintain a reliable and user-friendly interface for the majority of the
+# application's user base.

--- a/spec/features/standard_user_spec.rb
+++ b/spec/features/standard_user_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Standard User Tests', type: :feature do
     visit conservation_records_path
     click_on 'New Conservation Record'
     expect(page).to have_content('New Conservation Record')
+    fill_in 'Date received in preservation services', with: '04/15/2024'
     select('ARB Library', from: 'Department', match: :first)
     fill_in 'Title', with: conservation_record.title
     fill_in 'Author', with: conservation_record.author

--- a/spec/features/support/helpers/authentication_helpers.rb
+++ b/spec/features/support/helpers/authentication_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# authentication_helpers.rb contains a set of helper methods designed
+# to assist in managing user authentication across various RSpec tests.
+# These methods facilitate common authentication tasks such as logging
+# users in and out, which are essential for testing different parts
+# of the application with various access levels. Additionally, this file
+# includes methods to verify that users can only access areas of the
+# application appropriate for their permission levels, ensuring robust s
+# ecurity testing. By centralizing these methods here, we reduce code
+# duplication and increase the maintainability of our tests. This setup
+# allows for easy updates and extensions as the authentication requirements
+# of the application evolve.

--- a/spec/features/support/helpers/authentication_helpers.rb
+++ b/spec/features/support/helpers/authentication_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # authentication_helpers.rb contains a set of helper methods designed
 # to assist in managing user authentication across various RSpec tests.
 # These methods facilitate common authentication tasks such as logging
@@ -10,3 +11,8 @@
 # duplication and increase the maintainability of our tests. This setup
 # allows for easy updates and extensions as the authentication requirements
 # of the application evolve.
+
+require 'rails_helper'
+
+module AuthenticationHelpers
+end

--- a/spec/features/support/helpers/pdf_download_helpers.rb
+++ b/spec/features/support/helpers/pdf_download_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# pdf_download_helpers.rb includes helper methods specific to testing
+# PDF download functionalities within the application. Currently, this
+# file provides utilities to trigger and verify the download of PDFs,
+# such as ensuring that a PDF download initiates when a user clicks a
+# download button. This functionality is critical for validating that
+# our document generation systems work as expected across various user
+# interactions. While the scope of this helper is presently focused on
+# download checks, it is designed to be extensible. Future enhancements
+# may include additional checks for the content and formatting of
+# downloaded PDFs, which would further solidify the reliability of our
+# document handling features.

--- a/spec/features/support/shared_contexts/admin_user_context.rb
+++ b/spec/features/support/shared_contexts/admin_user_context.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# This file, admin_user_context.rb, defines a shared context for RSpec
+# tests that require an admin user to be logged in before the test actions
+# can be performed. This context is crucial for tests that involve
+# admin-only functionalities, such as managing users or accessing
+# administrative dashboards. The context handles the setup and teardown
+# processes by logging in an admin user at the beginning of each test and
+# ensuring they are logged out at the end if necessary. Usage of this file
+# helps avoid duplication of login logic across multiple test files and
+# ensures consistency in how admin sessions are handled during tests.

--- a/spec/features/support/shared_contexts/read_only_user_context.rb
+++ b/spec/features/support/shared_contexts/read_only_user_context.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# The read_only_user_context.rb file provides a shared context for
+# setting up a read-only user in RSpec tests. This context is essential
+# for scenarios where the tests must verify that read-only permissions
+# are respected across various parts of the application. For instance,
+# it ensures that read-only users cannot create, edit, or delete records
+# but can view data as expected. By centralizing the login and setup
+# for read-only users here, we ensure that all tests involving these
+# users start with a consistent state, improving test reliability and
+# reducing redundancy across test suites that need to simulate a
+# read-only user environment.

--- a/spec/features/support/shared_contexts/standard_user_context.rb
+++ b/spec/features/support/shared_contexts/standard_user_context.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# standard_user_context.rb establishes a shared RSpec context used for
+# testing functionalities available to standard users. This includes
+# actions like creating, viewing, editing, and deleting records, which
+# are permitted for standard users but executed under specific constraints
+# compared to administrators. The context ensures that a standard user
+# is correctly authenticated at the start of each test, providing a
+# clean and consistent testing environment. This file is critical for
+# validating the application's core functionality from the perspective
+# of most end-users, ensuring that standard user privileges and restrictions
+# are correctly implemented and maintained.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,19 +12,19 @@ require 'paper_trail/frameworks/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
+# spec/shared_contexts/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/shared_contexts that end
 # in _spec.rb will both be required and run as specs, causing the specs to be
 # run twice. It is recommended that you do not name files matching this glob to
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
 # The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
+# of increasing the boot-up time by auto-requiring all files in the shared_contexts
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
+# require only the shared_contexts files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+# Dir[Rails.root.join('spec', 'shared_contexts', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,71 +1,87 @@
 # frozen_string_literal: true
 
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-Rails.env = 'test'
-require File.expand_path('../config/environment', __dir__)
+# This file is part of the RSpec configuration when 'rails generate rspec:install' is run.
+# It sets up the test environment for RSpec.
+require 'dotenv'
+Dotenv.load('.env.test') # Make sure this is the first thing after requiring dotenv
+
+# Set the environment to test if it is not already set
+Rails.env = 'test' if Rails.env.development?
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'factory_bot'
+# Load Rails and core components
+require File.expand_path('../config/environment', __dir__)
+
+# Requires the standard RSpec helpers.
+require 'spec_helper'
 require 'rspec/rails'
+
+# Additional requires for test-specific functionalities.
+require 'capybara/rspec'
+require 'factory_bot_rails'
 require 'paper_trail/frameworks/rspec'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/shared_contexts/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/shared_contexts that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the shared_contexts
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the shared_contexts files necessary.
-#
-# Dir[Rails.root.join('spec', 'shared_contexts', '**', '*.rb')].each { |f| require f }
+# Load all feature-specific support files.
+Dir[Rails.root.join('spec/features/support/**/*.rb')].each { |f| require f }
 
-# Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove these lines.
+# Configure Capybara to use Selenium with headless Chrome for all tests
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.args << '--headless'
+  options.args << '--disable-gpu' # GPU acceleration isn't useful for headless testing.
+  options.args << '--no-sandbox'  # Recommended for CI environments, remove if causes issues locally.
+  options.add_argument('--disable-dev-shm-usage') # avoid issues in confined environments like Docker containers
+
+  options.add_preference(:loggingPrefs, { browser: 'ALL' })
+  options.add_preference(:download, {
+                           prompt_for_download: false, # Do not prompt for download
+                           default_directory: '/dev/null' # Discard all downloaded files
+                         })
+  options.add_preference(:plugins, {
+                           always_open_pdf_externally: false # Do not open PDFs externally
+                         })
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+end
+
+# Set Capybara's default and JavaScript driver to Selenium with headless Chrome
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
+
+# Ensures the database schema is up-to-date before running any tests
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
-RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures').to_s
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
+RSpec.configure do |config|
+  # Configure RSpec to manage fixtures location.
+  config.fixture_path = Rails.root.join('spec/fixtures')
+  # Use transactional fixtures to maintain a clean state between tests.
   config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  # Filter lines from Rails gems in backtraces.
+  # Filter out framework and any third-party gems from backtraces to minimize noise.
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+  # Optionally filter additional gems with config.filter_gems_from_backtrace("gem name")
+
+  # Include FactoryBot syntax to simplify calls to factories.
   config.include FactoryBot::Syntax::Methods
 
+  # Load seeds before running tests to ensure that test environment reflects
+  # production seed data.
   Rails.application.load_seed
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include AuthenticationHelpers, type: :feature
+  config.include PDFDownloadHelpers, type: :feature
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,7 @@ RSpec.configure do |config|
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   #   config.filter_run_when_matching :focus
   #
-  #   # Allows RSpec to persist some state between runs in order to support
+  #   # Allows RSpec to persist some state between runs in order to shared_contexts
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.
   #   config.example_status_persistence_file_path = "spec/examples.txt"

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe 'conservation_records/index', type: :view do
   include Devise::Test::ControllerHelpers
   include Pagy::Backend
+
   before do
     StaffCode.create(code: 'C', points: 10)
-    @conservation_record1 = ConservationRecord.create(
+
+    @conservation_record1 = ConservationRecord.create!(
       date_received_in_preservation_services: Date.new,
       department: 'Department',
       title: 'Title',
@@ -17,7 +19,7 @@ RSpec.describe 'conservation_records/index', type: :view do
       item_record_number: 'Item Record Number',
       digitization: false
     )
-    @conservation_record2 = ConservationRecord.create(
+    @conservation_record2 = ConservationRecord.create!(
       date_received_in_preservation_services: Date.new,
       department: 'Department',
       title: 'Title',
@@ -27,18 +29,18 @@ RSpec.describe 'conservation_records/index', type: :view do
       item_record_number: 'Item Record Number',
       digitization: false
     )
+    assign(:conservation_records, [@conservation_record1, @conservation_record2])
+    @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
+    render
   end
 
   it 'renders a list of conservation_records' do
-    @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
-    render
-    assert_select 'td', text: @conservation_record1.id.to_s, count: 1
-    assert_select 'td', text: @conservation_record2.id.to_s, count: 1
-    assert_select 'td', text: 'Title', count: 2
-    assert_select 'td', text: 'Title', count: 2
-    assert_select 'td', text: 'Author', count: 2
-    assert_select 'td', text: 'Call Number', count: 2
-    assert_select 'td', text: 'Item Record Number', count: 2
+    expect(rendered).to have_selector('td', text: @conservation_record1.id.to_s, count: 1)
+    expect(rendered).to have_selector('td', text: @conservation_record2.id.to_s, count: 1)
+    expect(rendered).to have_selector('td', text: 'Title', count: 2)
+    expect(rendered).to have_selector('td', text: 'Author', count: 2)
+    expect(rendered).to have_selector('td', text: 'Call Number', count: 2)
+    expect(rendered).to have_selector('td', text: 'Item Record Number', count: 2)
     expect(rendered).to have_link('Title')
   end
 
@@ -47,13 +49,10 @@ RSpec.describe 'conservation_records/index', type: :view do
     @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in @user
     @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
-    render
     expect(rendered).not_to have_button('New Conservation Record')
   end
 
   it 'displays a pagination widget' do
-    @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
-    render
-    expect(rendered).to have_text('<1>')
+    expect(rendered).to match(/>\s*1\s*</)
   end
 end


### PR DESCRIPTION
Ref #214

This PR reorganizes the rails_helper.rb file, adding in Capybara support for feature tests and the ability to use helper functions.  

When I moved the Capybara into the rails_helper.rb file, I discovered that some broken tests were being masked by non-functioning javascript testing, and that one of the tests was actually written in minitest insetad of rspec.

### File changes:

- spec/features/admin_user_spec.rb
  - Add filling in mandatory date field for cons. record creation
- spec/features/end_to_end_spec.rb
  - Removed now-redundant Capybara setup 
  - Standard user
    - Add missing staff code for in-house repair field
    - Add filling in mandatory date field for cons. record creation 
    - Corrected click target "Condition" to "Treatment Proposal"
    - Add confirming to cons. record deletion
  - Admin user
    -  Add missing staff code for in-house repair field
    - Add filling in mandatory date field for cons. record creation 
    - Add confirming to in-house and external repair record deletion
    - Refactor 200-status check for confirming PDF generation due to type of Capybara being used not supporting `expect(page.status_code).to eq(200)`
    - Corrected location for "Details" link
- spec/features/read_only_user_spec.rb
  - Removed now-redundant Capybara setup  
- spec/features/standard_user_spec.rb
  -   Add filling in mandatory date field for cons. record creation 
- spec/features/support/helpers/authentication_helpers.rb
  - Created skeleton so that it could be imported in rails_helper.rb
- spec/features/support/helpers/pdf_download_helpers.rb
  - Helper module that checks that when a pdf download link is clicked, a 200-code is returned.  Follows redirects as needed.  Will print (`puts`) end result if 200-status is not reached.   
- spec/rails_helper.rb
  - Explicitly require dotenv and load testing environment
  - Clarify to set env to "test" if in "development", allowing for aborting tests if in production
  - Set up Capybara
  - Loaded support helper files
  - Explicitly loaded feature support modules for Devise, as well as Authentication and PDF-checking modules
  - Removed unnecessary comments, clarified some comments, rearranged lines for clarity and best function
- spec/views/conservation_records/index.html.erb_spec.rb
  - Refactored non-functioning tests from minitest to rspec 😱    
  - Corrected broken pagy setup
  - Corrected inaccurate Pagy test check from `'<1>'` to `match(/>\s*1\s*</)` which will look for a visible text of "> 1 <", allowing for unspecified whitespace around the "1".  There will only be 2 records, so there won't be more than 1 page.

