### PR TITLE
MERGE TO FEATURE BRANCH - 214 - Use Context for Login - MERGE FIRST

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'ed25519'
   gem 'factory_bot_rails'
+  gem 'launchy'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 4.1.0'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.0.0)
     concurrent-ruby (1.2.3)
     coveralls_reborn (0.28.0)
       simplecov (~> 0.22.0)
@@ -163,6 +164,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
+    launchy (3.0.0)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -426,6 +430,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder (~> 2.5)
   jquery-rails
+  launchy
   mysql2
   nokogiri (>= 1.13)
   pagy

--- a/spec/features/specs/user_scenarios/admin_user_spec.rb
+++ b/spec/features/specs/user_scenarios/admin_user_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
-# admin_user_spec.rb is dedicated to testing the functionalities
-# and permissions unique to administrative users within the application.
-# This spec file assesses the ability of admin users to access and
-# interact with administrative-specific features, such as user and settings
-# management. It ensures that all administrative actions are secured and
-# function correctly, reflecting the critical role of admins in maintaining
-# the system. It checks that these users can perform their tasks without
-# encountering unauthorized access errors or other barriers.
+
+require 'rails_helper'
+
+RSpec.describe "Admin User Functionalities", type: :feature do
+  include_context "admin user context"
+
+  it "passes a test" do
+    expect(1).to eq(1)
+  end
+
+end

--- a/spec/features/specs/user_scenarios/admin_user_spec.rb
+++ b/spec/features/specs/user_scenarios/admin_user_spec.rb
@@ -2,11 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe "Admin User Functionalities", type: :feature do
-  include_context "admin user context"
+RSpec.describe 'Admin User Functionalities', type: :feature do
+  include_context 'admin user context'
 
-  it "passes a test" do
+  it 'passes a test' do
     expect(1).to eq(1)
   end
-
 end

--- a/spec/features/specs/user_scenarios/read_only_user_spec.rb
+++ b/spec/features/specs/user_scenarios/read_only_user_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
-# read_only_user_spec.rb tests the application from the perspective
-# of users with read-only access. It verifies that these users can view
-# documents and data as expected but are restricted from creating,
-# editing, or deleting any records. This spec ensures that the application
-# enforces these permissions correctly, crucial for maintaining data
-# integrity and security. By confirming that read-only users cannot
-# perform unauthorized actions, this spec helps safeguard the application
-# against potential data manipulation or accidental changes by users without
-# adequate privileges.
+
+require 'rails_helper'
+
+RSpec.describe "Read-Only User Functionalities", type: :feature do
+  include_context "read-only user context"
+
+  it "passes a test" do
+    expect(1).to eq(1)
+  end
+
+end

--- a/spec/features/specs/user_scenarios/read_only_user_spec.rb
+++ b/spec/features/specs/user_scenarios/read_only_user_spec.rb
@@ -2,11 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe "Read-Only User Functionalities", type: :feature do
-  include_context "read-only user context"
+RSpec.describe 'Read-Only User Functionalities', type: :feature do
+  include_context 'read-only user context'
 
-  it "passes a test" do
+  it 'passes a test' do
     expect(1).to eq(1)
   end
-
 end

--- a/spec/features/specs/user_scenarios/standard_user_spec.rb
+++ b/spec/features/specs/user_scenarios/standard_user_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
-# standard_user_spec.rb evaluates the application's functionality for standard
-# users, who have permissions to create, view, edit, and delete records within
-# their scope of access. This spec file tests the core functionalities
-# accessible to most users, ensuring they operate as intended. It's crucial
-# for verifying that standard users experience the application correctly,
-# with all intended functionalities available and working properly. These tests
-# help maintain a reliable and user-friendly interface for the majority of the
-# application's user base.
+
+require 'rails_helper'
+
+RSpec.describe "Standard User Functionalities", type: :feature do
+  include_context "standard user context"
+
+  it "passes a test" do
+    expect(1).to eq(1)
+  end
+
+end

--- a/spec/features/specs/user_scenarios/standard_user_spec.rb
+++ b/spec/features/specs/user_scenarios/standard_user_spec.rb
@@ -2,11 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe "Standard User Functionalities", type: :feature do
-  include_context "standard user context"
+RSpec.describe 'Standard User Functionalities', type: :feature do
+  include_context 'standard user context'
 
-  it "passes a test" do
+  it 'passes a test' do
     expect(1).to eq(1)
   end
-
 end

--- a/spec/features/support/helpers/authentication_helpers.rb
+++ b/spec/features/support/helpers/authentication_helpers.rb
@@ -8,13 +8,24 @@ module AuthenticationHelpers
     fill_in 'Email', with: user.email
     fill_in 'Password', with: 'notapassword' # from the factory
     click_button 'Log in'
+    validate_login_success
+  end
 
-    aggregate_failures "checking login and dashboard access" do
-      expect(page).to have_content('Signed in successfully')
-      expect(page).to have_content('Conservation Records')
-      expect(page).to_not have_content('Invalid Email or password.')
-      expect(page).to_not have_content('Log in')
-      expect(page).to_not have_content('You are already signed in.')
-    end
+  private
+
+  def validate_login_success
+    check_successful_sign_in
+    check_no_error_messages
+  end
+
+  def check_successful_sign_in
+    expect(page).to have_content('Signed in successfully')
+    expect(page).to have_content('Conservation Records')
+  end
+
+  def check_no_error_messages
+    expect(page).to_not have_content('Invalid Email or password.')
+    expect(page).to_not have_content('Log in')
+    expect(page).to_not have_content('You are already signed in.')
   end
 end

--- a/spec/features/support/helpers/authentication_helpers.rb
+++ b/spec/features/support/helpers/authentication_helpers.rb
@@ -3,4 +3,18 @@
 require 'rails_helper'
 
 module AuthenticationHelpers
+  def log_in_as_user(user)
+    visit new_user_session_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: 'notapassword' # from the factory
+    click_button 'Log in'
+
+    aggregate_failures "checking login and dashboard access" do
+      expect(page).to have_content('Signed in successfully')
+      expect(page).to have_content('Conservation Records')
+      expect(page).to_not have_content('Invalid Email or password.')
+      expect(page).to_not have_content('Log in')
+      expect(page).to_not have_content('You are already signed in.')
+    end
+  end
 end

--- a/spec/features/support/helpers/pdf_download_helpers.rb
+++ b/spec/features/support/helpers/pdf_download_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'uri'
 
@@ -32,4 +34,3 @@ module PDFDownloadHelpers
     puts response.body[0..2000] # Print the first 2000 characters of the body for deeper insight
   end
 end
-

--- a/spec/features/support/shared_contexts/admin_user_context.rb
+++ b/spec/features/support/shared_contexts/admin_user_context.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
-# This file, admin_user_context.rb, defines a shared context for RSpec
-# tests that require an admin user to be logged in before the test actions
-# can be performed. This context is crucial for tests that involve
-# admin-only functionalities, such as managing users or accessing
-# administrative dashboards. The context handles the setup and teardown
-# processes by logging in an admin user at the beginning of each test and
-# ensuring they are logged out at the end if necessary. Usage of this file
-# helps avoid duplication of login logic across multiple test files and
-# ensures consistency in how admin sessions are handled during tests.
+
+# Sets up and logs in an admin user for tests, using aggregate_failures to
+# report all login-related issues at once.
+RSpec.shared_context "admin user context", shared_context: :metadata do
+  let(:user) { create(:user, role: 'admin') }
+
+  before(:each) do
+    user
+    log_in_as_user(user)
+  end
+end

--- a/spec/features/support/shared_contexts/admin_user_context.rb
+++ b/spec/features/support/shared_contexts/admin_user_context.rb
@@ -2,7 +2,7 @@
 
 # Sets up and logs in an admin user for tests, using aggregate_failures to
 # report all login-related issues at once.
-RSpec.shared_context "admin user context", shared_context: :metadata do
+RSpec.shared_context 'admin user context', shared_context: :metadata do
   let(:user) { create(:user, role: 'admin') }
 
   before(:each) do

--- a/spec/features/support/shared_contexts/read_only_user_context.rb
+++ b/spec/features/support/shared_contexts/read_only_user_context.rb
@@ -2,7 +2,7 @@
 
 # Sets up and logs in an admin user for tests, using aggregate_failures to
 # report all login-related issues at once.
-RSpec.shared_context "read-only user context", shared_context: :metadata do
+RSpec.shared_context 'read-only user context', shared_context: :metadata do
   let(:user) { create(:user, role: 'read_only') }
 
   before(:each) do

--- a/spec/features/support/shared_contexts/read_only_user_context.rb
+++ b/spec/features/support/shared_contexts/read_only_user_context.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
-# The read_only_user_context.rb file provides a shared context for
-# setting up a read-only user in RSpec tests. This context is essential
-# for scenarios where the tests must verify that read-only permissions
-# are respected across various parts of the application. For instance,
-# it ensures that read-only users cannot create, edit, or delete records
-# but can view data as expected. By centralizing the login and setup
-# for read-only users here, we ensure that all tests involving these
-# users start with a consistent state, improving test reliability and
-# reducing redundancy across test suites that need to simulate a
-# read-only user environment.
+
+# Sets up and logs in an admin user for tests, using aggregate_failures to
+# report all login-related issues at once.
+RSpec.shared_context "read-only user context", shared_context: :metadata do
+  let(:user) { create(:user, role: 'read_only') }
+
+  before(:each) do
+    user
+    log_in_as_user(user)
+  end
+end

--- a/spec/features/support/shared_contexts/standard_user_context.rb
+++ b/spec/features/support/shared_contexts/standard_user_context.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
-# standard_user_context.rb establishes a shared RSpec context used for
-# testing functionalities available to standard users. This includes
-# actions like creating, viewing, editing, and deleting records, which
-# are permitted for standard users but executed under specific constraints
-# compared to administrators. The context ensures that a standard user
-# is correctly authenticated at the start of each test, providing a
-# clean and consistent testing environment. This file is critical for
-# validating the application's core functionality from the perspective
-# of most end-users, ensuring that standard user privileges and restrictions
-# are correctly implemented and maintained.
+
+# Sets up and logs in an admin user for tests, using aggregate_failures to
+# report all login-related issues at once.
+RSpec.shared_context "standard user context", shared_context: :metadata do
+  let(:user) { create(:user, role: 'standard') }
+
+  before(:each) do
+    user
+    log_in_as_user(user)
+  end
+end

--- a/spec/features/support/shared_contexts/standard_user_context.rb
+++ b/spec/features/support/shared_contexts/standard_user_context.rb
@@ -2,7 +2,7 @@
 
 # Sets up and logs in an admin user for tests, using aggregate_failures to
 # report all login-related issues at once.
-RSpec.shared_context "standard user context", shared_context: :metadata do
+RSpec.shared_context 'standard user context', shared_context: :metadata do
   let(:user) { create(:user, role: 'standard') }
 
   before(:each) do


### PR DESCRIPTION
Ref #214 

This pull request introduces shared contexts that utilize authentication_helpers to log in users for tests in features/specs/user_scenarios. These contexts standardize user authentication across specs, enhancing test reliability and reducing code redundancy.

### File Changes:
- Gemfile
  - Add "launchy" gem to make it easier to visualize feature tests mid-test
- spec/features/specs/user_scenarios/admin_user_spec.rb
  - Add admin context and a passing test
- spec/features/specs/user_scenarios/read_only_user_spec.rb
  - Add read_only context and a passing test   
- spec/features/specs/user_scenarios/standard_user_spec.rb
  - Add standard user context and a passing test
- spec/features/support/helpers/authentication_helpers.rb
  - created login helper and verification functions for it
- spec/features/support/shared_contexts/admin_user_context.rb
  - logged in admin user before any tests
- spec/features/support/shared_contexts/read_only_user_context.rb
  - logged in read_only user before any tests
- spec/features/support/shared_contexts/standard_user_context.rb
  - logged in standard user before any tests   