### PR TITLE
479 restrict standard user views

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,7 +40,7 @@ class Ability
       can :manage, :all
     when 'standard'
       can :view_pdfs, ConservationRecord
-      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, ConTechRecord, StaffCode, CostReturnReport, Report, :activity]
+      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, ConTechRecord, StaffCode, CostReturnReport]
     when 'read_only'
       can :view_pdfs, ConservationRecord
       can :read, ConservationRecord

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -19,8 +19,6 @@ namespace :export do
     end
 
     # set headers for repeat fields
-    err_csv = []
-
     def err_headings(ordinal)
       ["External Repair Record id #{ordinal + 1}",
        "External Repair repair_type #{ordinal + 1}",
@@ -30,11 +28,9 @@ namespace :export do
        "External Repair other_note #{ordinal + 1}"]
     end
 
-    err.max.times.each do |ordinal|
-      err_csv.push err_headings(ordinal)
+    err_csv = err.max.times.map do |ordinal|
+      err_headings(ordinal)
     end
-
-    ihrr_csv = []
 
     def ihrr_headings(ordinal)
       ["In House Repair performed_by_user_id #{ordinal + 1}",
@@ -45,8 +41,8 @@ namespace :export do
        "In House Repair staff_code #{ordinal + 1}"]
     end
 
-    ihrr.max.times.each do |ordinal|
-      ihrr_csv.push ihrr_headings(ordinal)
+    ihrr_csv = ihrr.max.times.map do |ordinal|
+      ihrr_headings(ordinal)
     end
 
     staff_csv = []

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReportsController, type: :controller do
 
   before do
     ActiveJob::Base.queue_adapter = :test
-    user = create(:user, role: 'standard')
+    user = create(:user, role: 'admin')
     sign_in(user)
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -73,13 +73,13 @@ describe 'User', type: :model do
       it { is_expected.to be_able_to(:update, ConTechRecord.new) }
       it { is_expected.to be_able_to(:destroy, ConTechRecord.new) }
 
-      it { is_expected.to be_able_to(:index, Report.new) }
-      it { is_expected.to be_able_to(:create, Report.new) }
-      it { is_expected.to be_able_to(:read, Report.new) }
-      it { is_expected.to be_able_to(:destroy, Report.new) }
+      it { is_expected.not_to be_able_to(:index, Report.new) }
+      it { is_expected.not_to be_able_to(:create, Report.new) }
+      it { is_expected.not_to be_able_to(:read, Report.new) }
+      it { is_expected.not_to be_able_to(:destroy, Report.new) }
 
-      it { is_expected.to be_able_to(:index, :activity) }
-      it { is_expected.to be_able_to(:show, :activity) }
+      it { is_expected.not_to be_able_to(:index, :activity) }
+      it { is_expected.not_to be_able_to(:show, :activity) }
     end
 
     context 'when is a read_only user' do

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe 'conservation_records/index', type: :view do
       item_record_number: 'Item Record Number',
       digitization: false
     )
+    ids = [@conservation_record1.id, @conservation_record2.id]
+    relation = ConservationRecord.where(id: ids)
+    @pagy, @conservation_records = pagy(relation, items: 100)
   end
 
   it 'renders a list of conservation_records' do
-    @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
     render
     assert_select 'td', text: @conservation_record1.id.to_s, count: 1
     assert_select 'td', text: @conservation_record2.id.to_s, count: 1
@@ -46,14 +48,18 @@ RSpec.describe 'conservation_records/index', type: :view do
     @user = create(:user, role: 'read_only')
     @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in @user
-    @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
     render
     expect(rendered).not_to have_button('New Conservation Record')
   end
 
   it 'displays a pagination widget' do
-    @pagy, @conservation_records = pagy(ConservationRecord.all, items: 100)
+    # Only 2 records, so the pagy widget should be disabled
     render
-    expect(rendered).to have_text('<1>')
+    expect(rendered).to have_css('nav.pagy-bootstrap-nav')
+    expect(rendered).to have_css('li.page-item.prev.disabled')
+    expect(rendered).to have_css('li.page-item.next.disabled')
+    expect(rendered).to have_css('a[aria-label="Previous"]', text: '<')
+    expect(rendered).to have_css('a[aria-label="Next"]', text: '>')
   end
+
 end

--- a/spec/views/conservation_records/index.html.erb_spec.rb
+++ b/spec/views/conservation_records/index.html.erb_spec.rb
@@ -61,5 +61,4 @@ RSpec.describe 'conservation_records/index', type: :view do
     expect(rendered).to have_css('a[aria-label="Previous"]', text: '<')
     expect(rendered).to have_css('a[aria-label="Next"]', text: '>')
   end
-
 end


### PR DESCRIPTION
Fixes #479 

We didn't intend to give standard users access to the reports and activity pages.  This PR revokes those permissions, updating tests to match the new permissions.

spec/views/conservation_records/index.html.erb_spec.rb was modified because it was failing pagination checks.

