### PR TITLE
482 - Correct staff codes access

### DIFF
--- a/app/controllers/staff_codes_controller.rb
+++ b/app/controllers/staff_codes_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StaffCodesController < ApplicationController
-  before_action :set_staff_code, only: %i[show edit update destroy]
+  before_action :set_staff_code, only: %i[show edit update]
   before_action :authenticate_user!
   load_and_authorize_resource
 
@@ -46,15 +46,6 @@ class StaffCodesController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @staff_code.errors, status: :unprocessable_entity }
       end
-    end
-  end
-
-  # DELETE /staff_codes/1 or /staff_codes/1.json
-  def destroy
-    @staff_code.destroy
-    respond_to do |format|
-      format.html { redirect_to staff_codes_url, notice: 'Staff code was successfully destroyed.' }
-      format.json { head :no_content }
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,6 +12,5 @@ class Users::RegistrationsController < Devise::RegistrationsController # rubocop
   def new
     flash[:notice] = 'Contact admin to request account'
     redirect_to new_user_session_path and return
-    super
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,9 +38,10 @@ class Ability
     case user.role
     when 'admin'
       can :manage, :all
+      cannot :destroy, StaffCode
     when 'standard'
       can :view_pdfs, ConservationRecord
-      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, ConTechRecord, StaffCode, CostReturnReport]
+      can :crud, [ConservationRecord, ExternalRepairRecord, InHouseRepairRecord, ConTechRecord, CostReturnReport]
     when 'read_only'
       can :view_pdfs, ConservationRecord
       can :read, ConservationRecord

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -30,6 +30,11 @@
              <%= link_to('Reports', reports_path, class: 'nav-link') %>
           </li>
         <% end %>
+        <% if can? :read, StaffCode %>
+          <li class="nav-item">
+            <%= link_to('Staff Codes', staff_codes_path, class: 'nav-link') %>
+          </li>
+        <% end %>
         <% if user_signed_in? %>
           <li class="nav-item">
             <%= form_with url: search_path, method: :get, local: true, class: "form-inline" do |f| %>

--- a/app/views/staff_codes/index.html.erb
+++ b/app/views/staff_codes/index.html.erb
@@ -19,7 +19,6 @@
         <td><%= link_to 'Show', staff_code %></td>
         <% if can? :crud, StaffCode %>
           <td><%= link_to 'Edit', edit_staff_code_path(staff_code) %></td>
-          <td><%= link_to 'Destroy', staff_code, method: :delete, data: { confirm: 'Are you sure?' } %></td>
         <% end %>
       </tr>
     <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.require_master_key = false
+
+  # Set the default URL for Devise
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,5 +49,4 @@ Rails.application.configure do
 
   # Set the default URL for Devise
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
-
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'from@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :staff_codes
+  resources :staff_codes, except: [:destroy]
   post 'users', to: 'users#create_user'
   resources :reports
   devise_for :users, controllers: { registrations: 'users/registrations' }

--- a/spec/controllers/staff_codes_controller_spec.rb
+++ b/spec/controllers/staff_codes_controller_spec.rb
@@ -142,19 +142,4 @@ RSpec.describe StaffCodesController, type: :controller do
       end
     end
   end
-
-  describe 'DELETE #destroy' do
-    it 'destroys the requested staff_code' do
-      staff_code = StaffCode.create! valid_attributes
-      expect do
-        delete :destroy, params: { id: staff_code.to_param }, session: valid_session
-      end.to change(StaffCode, :count).by(-1)
-    end
-
-    it 'redirects to the staff_codes list' do
-      staff_code = StaffCode.create! valid_attributes
-      delete :destroy, params: { id: staff_code.to_param }, session: valid_session
-      expect(response).to redirect_to(staff_codes_url)
-    end
-  end
 end

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_content('Staff Codes')
     expect(page).to have_link('Show')
     expect(page).to have_link('New Staff Code')
+    expect(page).to_not have_link('Delete')
+
+    # Edit Staff Codes
+    visit staff_codes_path
+    within('table') do
+      first(:link, 'Edit').click
+    end
+
+    expect(page).to have_content('Editing Staff Code')
 
     # Add Staff Codes
 
@@ -58,8 +67,10 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     find('a[href$="/edit"]', exact_text: 'Edit', visible: true).click
     expect(page).to have_content('Editing Staff Code')
 
-    # Edit Users
+    # Cannot delete staff codes
+    expect(page).to_not have_link('Delete')
 
+    # Edit Users
     visit conservation_records_path
     click_on 'Users'
     expect(page).to have_content('Users')

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     click_button 'Log in'
     expect(page).to have_content('Signed in successfully')
     expect(page).to have_link('Conservation Records')
+    expect(page).to have_link('Staff Codes')
 
     # Show Conservation Records
 
@@ -41,12 +42,6 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_link('Show')
     expect(page).to have_link('New Staff Code')
 
-    # Edit Staff Codes
-
-    visit staff_codes_path
-    click_link('Edit')
-    expect(page).to have_content('Editing Staff Code')
-
     # Add Staff Codes
 
     visit staff_codes_path
@@ -57,11 +52,11 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     click_on 'Create Staff code'
     expect(page).to have_content('Staff code was successfully created')
     expect(page).to have_content(staff_code.code)
+
     expect(page).to have_link('Edit')
 
     # Edit the existing Staff Code
-
-    click_link 'Edit'
+    find('a[href$="/edit"]', exact_text: 'Edit', visible: true).click
     expect(page).to have_content('Editing Staff Code')
 
     # Edit Users

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
 
     visit staff_codes_path
     expect(page).to have_content('Staff Codes')
-    expect(page).to have_link('Destroy')
     expect(page).to have_link('Show')
     expect(page).to have_link('New Staff Code')
 

--- a/spec/features/standard_user_spec.rb
+++ b/spec/features/standard_user_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Standard User Tests', type: :feature do
     expect(page).to have_no_link('Users')
     expect(page).to have_no_link('Activity')
     expect(page).to have_no_link('Vocabularies')
+    expect(page).to have_no_link('Staff Codes')
 
     # Show Conservation Records
 
@@ -54,37 +55,6 @@ RSpec.describe 'Standard User Tests', type: :feature do
 
     click_on 'Edit Conservation Record'
     expect(page).to have_content('Editing Conservation Record')
-
-    # Show Staff Codes
-
-    visit staff_codes_path
-    expect(page).to have_content('Staff Codes')
-    expect(page).to have_link('Destroy')
-    expect(page).to have_link('Show')
-    expect(page).to have_link('New Staff Code')
-
-    # Edit Staff Codes
-
-    visit staff_codes_path
-    click_link('Edit')
-    expect(page).to have_content('Editing Staff Code')
-
-    # Add Staff Codes
-
-    visit staff_codes_path
-    click_link 'New Staff Code'
-    expect(page).to have_content('New Staff Code')
-    fill_in 'Code', with: staff_code.code
-    fill_in 'Points', with: staff_code.points
-    click_on 'Create Staff code'
-    expect(page).to have_content('Staff code was successfully created')
-    expect(page).to have_content(staff_code.code)
-    expect(page).to have_link('Edit')
-
-    # Edit the existing Staff Code
-
-    click_link 'Edit'
-    expect(page).to have_content('Editing Staff Code')
 
     # In_House Repair
 

--- a/spec/helpers/in_house_repair_records_helper_spec.rb
+++ b/spec/helpers/in_house_repair_records_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe InHouseRepairRecordsHelper, type: :helper do
            repair_type: repair_type.id,
            conservation_record:,
            other_note: 'Please check spine',
-           staff_code_id: '1')
+           staff_code_id: staff_code.id)
   end
 
   it 'generates an in house repair string' do

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  it 'sets the default from' do
+    expect(ApplicationMailer.default[:from]).to eq('from@example.com')
+  end
+
+  it 'sets the layout' do
+    expect(ApplicationMailer._layout).to eq('mailer')
+  end
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe ApplicationMailer, type: :mailer do
   it 'sets the default from' do

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Devise::Mailer, type: :mailer do
   # This test verifies that the Devise mailer, which inherits from our ApplicationMailer,
@@ -24,7 +24,7 @@ RSpec.describe Devise::Mailer, type: :mailer do
 
     it 'includes link to reset password' do
       expect(mail.body.encoded)
-        .to match(/http:\/\/localhost:3000\/users\/password\/edit/)
+        .to match(%r{http://localhost:3000/users/password/edit})
     end
   end
 end

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Devise::Mailer, type: :mailer do
+  # This test verifies that the Devise mailer, which inherits from our ApplicationMailer,
+  # is able to send emails correctly. By testing the Devise mailer, we indirectly test
+  # our ApplicationMailer, ensuring that it is properly set up for sending emails.
+  describe '#reset_password_instructions' do
+    let(:user) { create(:user) }
+    let(:mail) { described_class.reset_password_instructions(user, user.reset_password_token) }
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('Reset password instructions')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eq(['from@example.com'])
+    end
+
+    it 'includes link to reset password' do
+      expect(mail.body.encoded)
+        .to match(/http:\/\/localhost:3000\/users\/password\/edit/)
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -55,11 +55,11 @@ describe 'User', type: :model do
       it { is_expected.to be_able_to(:update, InHouseRepairRecord.new) }
       it { is_expected.to be_able_to(:destroy, InHouseRepairRecord.new) }
 
-      it { is_expected.to be_able_to(:index, StaffCode.new) }
-      it { is_expected.to be_able_to(:create, StaffCode.new) }
-      it { is_expected.to be_able_to(:read, StaffCode.new) }
-      it { is_expected.to be_able_to(:update, StaffCode.new) }
-      it { is_expected.to be_able_to(:destroy, StaffCode.new) }
+      it { is_expected.not_to be_able_to(:index, StaffCode.new) }
+      it { is_expected.not_to be_able_to(:create, StaffCode.new) }
+      it { is_expected.not_to be_able_to(:read, StaffCode.new) }
+      it { is_expected.not_to be_able_to(:update, StaffCode.new) }
+      it { is_expected.not_to be_able_to(:destroy, StaffCode.new) }
 
       it { is_expected.to be_able_to(:index, CostReturnReport.new) }
       it { is_expected.to be_able_to(:create, CostReturnReport.new) }

--- a/spec/requests/staff_codes_spec.rb
+++ b/spec/requests/staff_codes_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'StaffCodes', type: :request do
   before do
-    user = create(:user, role: 'standard')
+    user = create(:user, role: 'admin')
     sign_in user
   end
 

--- a/spec/routing/staff_codes_routing_spec.rb
+++ b/spec/routing/staff_codes_routing_spec.rb
@@ -31,9 +31,5 @@ RSpec.describe StaffCodesController, type: :routing do
     it 'routes to #update via PATCH' do
       expect(patch: '/staff_codes/1').to route_to('staff_codes#update', id: '1')
     end
-
-    it 'routes to #destroy' do
-      expect(delete: '/staff_codes/1').to route_to('staff_codes#destroy', id: '1')
-    end
   end
 end


### PR DESCRIPTION
We had no link on the admin header for staff codes, and standard users were able to access this page.

This PR corrects these two errors, adding a link in the admin header and removing access for the standard users.

Additionally, we are removing the ability for any user to delete or destroy a staff code.  If the preservation team needs to remove a staff code in the future, we will need to do it for them.

File changes:
- app/controllers/staff_codes_controller.rb
  - remove delete method 
- app/models/ability.rb
  - removes standard user access to staff codes
  - removes admin ability to delete staff codes
- app/views/shared/_navigation.html.erb
  - adds link for staff codes to permitted users (admin-only)
- app/views/staff_codes/index.html.erb
  - remove links to destroy staff codes
- config/routes.rb
  - remove destroy routing for staff codes
- spec/controllers/staff_codes_controller_spec.rb
  - remove testing for deleting records
-  spec/features/admin_user_spec.rb
  - expect admins to have a link 
  - remove duplication of check for staff codes editing
  - fix link specification
- spec/features/standard_user_spec.rb
  - update standard user tests to check that they cannot access staff codes
- spec/helpers/in_house_repair_records_helper_spec.rb
  - broken test due to previous update adding in staff code seed data
- spec/models/ability_spec.rb
  - update checks on abilities for standard user
- spec/requests/staff_codes_spec.rb
  - update now-failing test
- spec/routing/staff_codes_routing_spec.rb
  - remove test for destroy routing

Additional changes to increase coveralls %

These changes reduced the number of lines in controllers, and thus reduced the % of testing.  I discovered an unreachable call to "super" in `app/controllers/users/registrations_controller.rb` which couldn't be tested because it was never called.  Deleting this line increased our testing % from -0.1% to -0.01%.

Adding and configuring a test for the Devise mailer allows us to indirectly test our ApplicationMailer.  Devise inherits from the ApplicationMailer class.  We're not using the ApplicationMailer directly anywhere, but Devise will pull defaults from our class.  This was as close as I could get to testing ApplicationMailer.  

This increase in testing was not recognized by Coveralls, so I created yet another file: spec/mailers/application_mailer_spec.rb which has some very simple tests about the content of that class.  This bumped our spec % from -0.01% to +0.5%