### PR TITLE
MERGE TO FEATURE - 214 Read only conservation record checks - MERGE FIRST

### DIFF
--- a/app/views/treatment_reports/_abbreviated_treatment_report_form.html.erb
+++ b/app/views/treatment_reports/_abbreviated_treatment_report_form.html.erb
@@ -8,7 +8,6 @@
       <p>
         <%= f.text_area :abbreviated_treatment_report, class: 'form-control' %>
       </p>
-
       <p>
         <%= f.submit 'Save Abbreviated Treatment Report', class: 'btn btn-primary' %>
     </div>

--- a/app/views/treatment_reports/_form.html.erb
+++ b/app/views/treatment_reports/_form.html.erb
@@ -18,144 +18,141 @@
 </ul>
 
 <%= form_with(model: [@conservation_record, @conservation_record.treatment_report], class: 'disable_input') do |f| %>
-<div class="tab-content" id="myTabContent">
-  <div class="tab-pane fade show active" id="description" role="tabpanel" aria-labelledby="description-tab">
-    <div class="form-group">
+  <div class="tab-content" id="myTabContent">
+    <div class="tab-pane fade show active" id="description" role="tabpanel" aria-labelledby="description-tab">
+      <div class="form-group">
+        <p>
+          <%= f.label :General_Remarks, "General Remarks" %>
+          <%= f.text_area :description_general_remarks, class: 'form-control' %>
+        </p>
+
+        <p>
+          <%= f.label :Binding, "Binding" %>
+          <%= f.text_area :description_binding, class: 'form-control' %>
+        </p>
+
+        <p>
+          <%= f.label :textblock, "Text Block" %>
+          <%= f.text_area :description_textblock, class: 'form-control' %>
+        </p>
+
+        <p>
+          <%= f.label :primary_support, "Primary Support" %>
+          <%= f.text_area :description_primary_support, class: 'form-control' %>
+        </p>
+
+        <p>
+          <%= f.label :medium, "Medium" %>
+          <%= f.text_area :description_medium, class: 'form-control' %>
+        </p>
+
+        <p>
+          <%= f.label :Attachments_Inserts, "Attachments | Inserts" %>
+          <%= f.text_area :description_attachments_inserts, class: 'form-control' %>
+        </p>
+
+        <p>
+          <%= f.label :Housing, "Housing" %>
+          <%= f.text_area :description_housing, class: 'form-control' %>
+        </p>
+      </div>
+    </div>
+    <div class="tab-pane fade" id="condition" role="tabpanel" aria-labelledby="condition-tab">
       <p>
-        <%= f.label :General_Remarks, "General Remarks" %>
-        <%= f.text_area :description_general_remarks, class: 'form-control' %>
+        <%= f.label :Summary, "Summary" %>
+        <%= f.text_area :condition_summary, class: 'form-control' %>
       </p>
 
       <p>
         <%= f.label :Binding, "Binding" %>
-        <%= f.text_area :description_binding, class: 'form-control' %>
+        <%= f.text_area :condition_binding, class: 'form-control' %>
       </p>
 
       <p>
-        <%= f.label :textblock, "Text Block" %>
-        <%= f.text_area :description_textblock, class: 'form-control' %>
+        <%= f.label :Textblock, "Text Block" %>
+        <%= f.text_area :condition_textblock, class: 'form-control' %>
       </p>
 
       <p>
-        <%= f.label :primary_support, "Primary Support" %>
-        <%= f.text_area :description_primary_support, class: 'form-control' %>
+        <%= f.label :Primary_Support, "Primary Support" %>
+        <%= f.text_area :condition_primary_support, class: 'form-control' %>
       </p>
 
       <p>
-        <%= f.label :medium, "Medium" %>
-        <%= f.text_area :description_medium, class: 'form-control' %>
-      </p>
-
-      <p>
-        <%= f.label :Attachments_Inserts, "Attachments | Inserts" %>
-        <%= f.text_area :description_attachments_inserts, class: 'form-control' %>
+        <%= f.label :Medium, "Medium" %>
+        <%= f.text_area :condition_medium, class: 'form-control' %>
       </p>
 
       <p>
         <%= f.label :Housing, "Housing" %>
-        <%= f.text_area :description_housing, class: 'form-control' %>
+        <%= f.select(:condition_housing_id, options_from_collection_for_select(@housing, "id", "key", @conservation_record.treatment_report.condition_housing_id), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
+      </p>
+
+      <p>
+        <%= f.label :Housing_Narrative, "Housing Narrative" %>
+        <%= f.text_area :condition_housing_narrative, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Attachments_Inserts, "Attachments | Inserts" %>
+        <%= f.text_area :condition_attachments_inserts, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Previous_Treatment, "Previous Treatment" %>
+        <%= f.text_area :condition_previous_treatment, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Materials_Analysis, "Materials Analysis" %>
+        <%= f.text_area :condition_materials_analysis, class: 'form-control' %>
       </p>
     </div>
+    <div class="tab-pane fade" id="treatment-proposal" role="tabpanel" aria-labelledby="treatment-proposal-tab">
+      <p>
+        <%= f.label :Proposal, "Proposal" %>
+        <%= f.text_area :treatment_proposal_proposal, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Housing_Need, "Housing Need" %>
+        <%= f.select(:treatment_proposal_housing_need_id, options_from_collection_for_select(@housing, "id", "key", @conservation_record.treatment_report.treatment_proposal_housing_need_id), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
+      </p>
+
+      <p>
+        <%= f.label :Factors_Influencing_Treatment, "Factors Influencing Treatment" %>
+        <%= f.text_area :treatment_proposal_factors_influencing_treatment, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Performed_Treatment, "Performed Treatment" %>
+        <%= f.text_area :treatment_proposal_performed_treatment, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Housing_Provided, "Housing Provided" %>
+        <%= f.select(:treatment_proposal_housing_provided_id, options_from_collection_for_select(@housing, "id", "key", @conservation_record.treatment_report.treatment_proposal_housing_provided_id), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
+      </p>
+
+      <p>
+        <%= f.label :Housing_Narrative, "Housing Narrative" %>
+        <%= f.text_area :treatment_proposal_housing_narrative, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Storage_and_Handling_Notes, "Storage and Handling Notes" %>
+        <%= f.text_area :treatment_proposal_storage_and_handling_notes, class: 'form-control' %>
+      </p>
+
+      <p>
+        <%= f.label :Total_Treatment_Time, "Total Treatment Time" %>
+        <%= f.text_area :treatment_proposal_total_treatment_time, class: 'form-control' %>
+      </p>
+
+    </div>
   </div>
-  <div class="tab-pane fade" id="condition" role="tabpanel" aria-labelledby="condition-tab">
-    <p>
-      <%= f.label :Summary, "Summary" %>
-      <%= f.text_area :condition_summary, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Binding, "Binding" %>
-      <%= f.text_area :condition_binding, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Textblock, "Text Block" %>
-      <%= f.text_area :condition_textblock, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Primary_Support, "Primary Support" %>
-      <%= f.text_area :condition_primary_support, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Medium, "Medium" %>
-      <%= f.text_area :condition_medium, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Housing, "Housing" %>
-      <%= f.select(:condition_housing_id, options_from_collection_for_select(@housing, "id", "key", @conservation_record.treatment_report.condition_housing_id), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
-    </p>
-
-    <p>
-      <%= f.label :Housing_Narrative, "Housing Narrative" %>
-      <%= f.text_area :condition_housing_narrative, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Attachments_Inserts, "Attachments | Inserts" %>
-      <%= f.text_area :condition_attachments_inserts, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Previous_Treatment, "Previous Treatment" %>
-      <%= f.text_area :condition_previous_treatment, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Materials_Analysis, "Materials Analysis" %>
-      <%= f.text_area :condition_materials_analysis, class: 'form-control' %>
-    </p>
-  </div>
-  <div class="tab-pane fade" id="treatment-proposal" role="tabpanel" aria-labelledby="treatment-proposal-tab">
-    <p>
-      <%= f.label :Proposal, "Proposal" %>
-      <%= f.text_area :treatment_proposal_proposal, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Housing_Need, "Housing Need" %>
-      <%= f.select(:treatment_proposal_housing_need_id, options_from_collection_for_select(@housing, "id", "key", @conservation_record.treatment_report.treatment_proposal_housing_need_id), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
-    </p>
-
-    <p>
-      <%= f.label :Factors_Influencing_Treatment, "Factors Influencing Treatment" %>
-      <%= f.text_area :treatment_proposal_factors_influencing_treatment, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Performed_Treatment, "Performed Treatment" %>
-      <%= f.text_area :treatment_proposal_performed_treatment, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Housing_Provided, "Housing Provided" %>
-      <%= f.select(:treatment_proposal_housing_provided_id, options_from_collection_for_select(@housing, "id", "key", @conservation_record.treatment_report.treatment_proposal_housing_provided_id), { prompt: 'Select Housing' }, { :class => 'form-control' }) %>
-    </p>
-
-    <p>
-      <%= f.label :Housing_Narrative, "Housing Narrative" %>
-      <%= f.text_area :treatment_proposal_housing_narrative, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Storage_and_Handling_Notes, "Storage and Handling Notes" %>
-      <%= f.text_area :treatment_proposal_storage_and_handling_notes, class: 'form-control' %>
-    </p>
-
-    <p>
-      <%= f.label :Total_Treatment_Time, "Total Treatment Time" %>
-      <%= f.text_area :treatment_proposal_total_treatment_time, class: 'form-control' %>
-    </p>
-
-  </div>
-</div>
-
-
-<p>
-  <%= f.submit 'Save Treatment Report', class: 'btn btn-primary' %>
-</p>
-
-<% end %>
+  <p>
+    <%= f.submit 'Save Treatment Report', class: 'btn btn-primary' %>
+  </p>
+  <% end %>
 <br />

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -118,10 +118,6 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     vocabulary
   end
 
-  before do
-    vocabulary
-  end
-
   it 'allows User to login and show Conservation Records' do
     # Login
     log_in_as_user(user)

--- a/spec/features/specs/user_scenarios/read_only_user_spec.rb
+++ b/spec/features/specs/user_scenarios/read_only_user_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Read-Only User Functionalities', type: :feature do
   it_behaves_like 'index page access for authenticated users'
   it_behaves_like 'view conservation record details'
   it_behaves_like 'has a read_only user header'
+  it_behaves_like 'displays conservation records for read-only users correctly'
 
   it 'prevents read-only users from accessing New Conservation Records page' do
     prevents_unauthorized_access(new_conservation_record_path)

--- a/spec/features/support/shared_examples/read_only_checks/read_only_cons_record_check.rb
+++ b/spec/features/support/shared_examples/read_only_checks/read_only_cons_record_check.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'displays conservation records for read-only users correctly' do
+  let(:cons_record) { create(:conservation_record) }
+
+  before do
+    cons_record
+  end
+
+  it 'does not have buttons that it should not have' do
+    visit conservation_records_path
+    expect(page).not_to have_link('New Conservation Record')
+
+    within('table tbody') do
+      first('a').click
+    end
+
+    expect(page).not_to have_link('Edit Conservation Record')
+    expect(page).not_to have_link('Add In-House Repair')
+    expect(page).not_to have_link('Add External Repair')
+    expect(page).not_to have_link('Add Conservators and Technicians')
+  end
+
+  it 'has disabled conservation record buttons' do
+    visit conservation_records_path
+    within('table tbody') do
+      first('a').click
+    end
+
+    expect(page).to have_content('Cost and Return Information')
+    expect(page).to have_button('Save Cost and Return Information', disabled: true)
+    expect(page).to have_button('Save Treatment Report', disabled: true)
+    expect(page).to have_button('Save Cost and Return Information', disabled: true)
+  end
+
+  it 'has disabled input fields in the conservation record form' do
+    visit conservation_record_path(cons_record)
+    expect(page).to have_selector('h1', text: cons_record.title)
+    expect(page).to have_selector('form.disable_input')
+    all('form.disabled_input').each do |form|
+      within(form) do
+        # Check disabled state for all input, textarea, and select elements
+        %w[input textarea select].each do |element_type|
+          all(element_type).each do |element|
+            expect(element).to be_disabled
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/shared_examples/read_only_checks/read_only_cons_record_check.rb
+++ b/spec/features/support/shared_examples/read_only_checks/read_only_cons_record_check.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'displays conservation records for read-only users correct
     visit conservation_record_path(cons_record)
     expect(page).to have_selector('h1', text: cons_record.title)
     expect(page).to have_selector('form.disable_input')
-    all('form.disabled_input').each do |form|
+    all('form.disable_input').each do |form| # There are several forms on the page
       within(form) do
         # Check disabled state for all input, textarea, and select elements
         %w[input textarea select].each do |element_type|


### PR DESCRIPTION
We have some specific css and link/button visibility with read-only users.  This PR looks at the read-only user's perspective when looking at both the index page and a conservation record, and makes sure that it is only showing the links it should.  Read only users should not have links to create or edit conservation records, or to add new repairs or technicians.  They should have disabled input fields for the treatment report fields.


Other Changes
- app/views/treatment_reports/_abbreviated_treatment_report_form.html.erb - removed blank line
- app/views/treatment_reports/_form.html.erb - corrected form indentation.  Did not change form.
- spec/features/end_to_end_spec.rb - corrected duplicated code