### PR TITLE
FEATURE MERGE - 407 add gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,11 @@ gem 'brakeman', '~> 5.1', '>= 5.1.1'
 
 gem 'bigdecimal', '~> 3'
 
+#
+gem 'show_me_the_cookies' # Cookie inspection for tests
+
+gem 'omniauth-shibboleth' # Provides Shibboleth-based SSO authentication
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bcrypt_pbkdf'

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ gem 'brakeman', '~> 5.1', '>= 5.1.1'
 
 gem 'bigdecimal', '~> 3'
 
-#
 gem 'show_me_the_cookies' # Cookie inspection for tests
 
 gem 'omniauth-shibboleth' # Provides Shibboleth-based SSO authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,7 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.3)
       concurrent-ruby (~> 1.0)
       racc (~> 1.7)
@@ -209,6 +210,12 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-shibboleth (1.3.0)
+      omniauth (>= 1.0.0)
     orm_adapter (0.5.0)
     pagy (7.0.9)
     paper_trail (15.1.0)
@@ -225,6 +232,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8.1)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (6.1.7.7)
@@ -335,6 +345,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    show_me_the_cookies (6.0.0)
+      capybara (>= 2, < 4)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -428,6 +440,7 @@ DEPENDENCIES
   jquery-rails
   mysql2
   nokogiri (>= 1.13)
+  omniauth-shibboleth
   pagy
   paper_trail
   pdfkit
@@ -441,6 +454,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.0)
   selenium-webdriver (~> 4.18.1)
+  show_me_the_cookies
   simplecov
   simplecov-lcov
   spring


### PR DESCRIPTION
This PR adds the gems we expect to need to use while making the change to SSO.

We do not expect to need 'omniauth-openid' because we are integrating directly with Shibboleth and validating against a set list of approved users.  We do not allow any other time of login or account creation.