### PR TITLE
Decommission wkhtmltopdf_binary fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,4 +104,4 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # wkhtmltopdf uclibs fork
-gem 'wkhtmltopdf-binary', git: 'https://github.com/uclibs/wkhtmltopdf_binary_gem', branch: '153/oracle-linux-support'
+gem 'wkhtmltopdf-binary', '>= 0.12.6.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/uclibs/wkhtmltopdf_binary_gem
-  revision: 27fd641bbeb6af8adb96c64f82afa9481c1e5fd8
-  branch: 153/oracle-linux-support
-  specs:
-    wkhtmltopdf-binary (0.12.6.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -391,6 +384,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wkhtmltopdf-binary (0.12.6.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.13)
@@ -450,7 +444,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  wkhtmltopdf-binary!
+  wkhtmltopdf-binary (>= 0.12.6.7)
 
 RUBY VERSION
    ruby 3.3.0p0


### PR DESCRIPTION
Resolves #496 

Recent release of wkhtmltopdf_binary gem includes fix to accommodate oracle linux. We created a forked repo with PR to the parent that was accepted in most recent release, we can now decommission our fork.