### PR TITLE
513 - Upgrade sass-rails from ~>5.0 to ~>6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
 gem 'puma'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 6.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,17 +306,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -439,7 +430,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rails
-  sass-rails (~> 5.0)
+  sass-rails (~> 6.0)
   selenium-webdriver (~> 4.18.1)
   simplecov
   simplecov-lcov


### PR DESCRIPTION
Fixes #513 
Upon running "bundle install", we were getting an error message for the end of life for the gem `ruby-sass`.  

We weren't actually using `ruby-sass` directly, but our gem `sass-rails` was.  This warning was fixed in version 6.0.0 of `sass-rails`. (See https://github.com/rails/sass-rails/issues/435)

I updated our Gemfile from asking for `sass-rails (~> 5.0)` to asking for `sass-rails (~> 6.0)`.  Local testing has the app still working the same way, and our tests are still passing.  

