### PR TITLE
516 - Add filter for rake folder to spec_helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /yarn-error.log
 
 /public/assets
+/public/build/*
 .byebug_history
 
 # Ignore master key for decrypting credentials and more.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,11 +20,11 @@ require 'simplecov-lcov'
 require 'coveralls'
 
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  add_filter '/spec/'  # Exclude all files in the spec directory
+end
 
 SimpleCov.at_exit do
-  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
-  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
     [
       SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
Adds a filter for the SimpleCov setup and removes some duplications that could cause unexpected results.  

Also adds /public/build/* to .gitignore.