### PR TITLE
519 - Add shared rake test context

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'paper_trail/frameworks/rspec'
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
 # Auto-require all Ruby files in the spec/support directory.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,12 +19,8 @@ require 'paper_trail/frameworks/rspec'
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+# Auto-require all Ruby files in the spec/support directory.
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -35,6 +31,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  # Add shared context "rake" to rake task tests
+  config.include_context 'rake', type: :task
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures').to_s
 

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
+# Shared context for RSpec that loads all Rails and custom Capistrano rake tasks before
+# each test suite and clears the Rake environment after each individual test. This ensures
+# that each test starts with a fresh set of tasks and no residual state interferes with
+# subsequent tests.
+# This is invoked in spec/rails_helper.rb with the line `config.include_context 'rake', type: :task`,
+# which adds the shared context to all tests of type :task.
 RSpec.shared_context 'rake', shared_context: :metadata do
   before(:all) do
     Rails.application.load_tasks
-    Dir.glob(Rails.root.join('lib', 'capistrano', 'tasks', '*.rake')).each { |file| load file }
+    # Rails.root.glob('lib/capistrano/tasks/*.rake').each { |file| load file }
   end
 
   after(:each) do

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -9,7 +9,7 @@
 RSpec.shared_context 'rake', shared_context: :metadata do
   before(:all) do
     Rails.application.load_tasks
-    # Rails.root.glob('lib/capistrano/tasks/*.rake').each { |file| load file }
+    Rails.root.glob('lib/capistrano/tasks/*.rake').each { |file| load file }
   end
 
   after(:each) do

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'rake', shared_context: :metadata do
+  before(:all) do
+    Rails.application.load_tasks
+    Dir.glob(Rails.root.join('lib', 'capistrano', 'tasks', '*.rake')).each { |file| load file }
+  end
+
+  after(:each) do
+    Rake.application.clear
+  end
+end


### PR DESCRIPTION
Fixes #519 

This PR adds a shared context for the testing of Rake tasks, indicated in Rspec by `type :task`.  It loads the rake tasks we have, both custom and built-in, and then clears the Rake application after each test to help keep changes made in one test from affecting other tests.  These steps could be manually done in each test; this PR is to help keep code DRY and to assist in keeping rake tests from affecting the state of other rake tests.