### PR TITLE
524 - Add Staff Codes to seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -98,4 +98,29 @@ class AddSeedObjects < ActiveRecord::Migration[5.1]
       }
     ]
   )
+
+  StaffCode.create(
+    [
+      {
+        code: 'C',
+        points: 20
+      },
+      {
+        code: 'T',
+        points: 10
+      },
+      {
+        code: 'S',
+        points: 4
+      },
+      {
+        code: 'V',
+        points: 0
+      },
+      {
+        code: 'A',
+        points: 15
+      }
+    ]
+  )
 end


### PR DESCRIPTION
Modifies the db/seeds.rb file to add in Staff Codes when the command `rails db:seed` is run.  The codes match the codes currently used in production.

To test:
`rails db:drop`
`rails db:create`
`rails db:migrate`
`rails db:seed`
Log in as admin with email 'chuck@chuck.codes' and password 'notapass'
Go to the main conservation records index page.  You should see exactly three records.
Go to /staff_codes (you will need to manually type this address in - there are no links)
You should see the following:
![Screenshot 2024-07-09 at 2 02 47 PM](https://github.com/uclibs/treatment_database/assets/57018862/cbb09f92-2d4e-44cc-9d37-7d68e8a02c14)
