### PR TITLE
HOLD FOR BOOTSTRAP UPDATE - Update config/deploy/production.rb to match qa.rb's setup

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,10 +5,10 @@ set :bundle_without, %w[development test].join(' ')
 set :branch, 'main'
 set :default_env, path: '$PATH:/usr/local/bin'
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
-append :linked_dirs, 'tmp', 'log'
+append :linked_dirs, '.bundle', 'tmp', 'log'
 ask(:username, nil)
 ask(:password, nil, echo: false)
-server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22
+server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22, roles: %i[web app db]
 ask(:value, 'Have you submitted and received an approved Change Management Request? (Y)')
 if fetch(:value) != 'Y'
   puts "\nDeploy cancelled!"


### PR DESCRIPTION
We couldn't deploy to libapps (production) but we could deploy to libappstest (qa).  These changes mimic the setup in libappstest (qa) and allowed us to deploy this branch to libapps (production).