### PR TITLE
LIBTREATDB-72 Pull Capybara initialization code into support file for DRY code

### DIFF
--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'capybara'
-
-Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
-  browser_options = Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--no-sandbox'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless_sandboxless
 
 RSpec.describe 'Non-Authenticated User Tests', type: :feature do
   it 'asks user to login to view Conservation Records' do

--- a/spec/features/read_only_user_spec.rb
+++ b/spec/features/read_only_user_spec.rb
@@ -2,18 +2,6 @@
 
 require 'rails_helper'
 
-require 'capybara'
-
-Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
-  browser_options = Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--no-sandbox'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.default_driver = :rack_test # This is a faster driver
-Capybara.javascript_driver = :selenium_chrome_headless_sandboxless
-
 RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   let(:user) { create(:user, role: 'read_only') }
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 'ARB Library') }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'capybara/rspec'
+require 'selenium-webdriver'
+
+RSpec.configure do |_config|
+  Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
+    browser_options = Selenium::WebDriver::Chrome::Options.new
+    browser_options.args << '--headless'
+    browser_options.args << '--disable-gpu'
+    browser_options.args << '--no-sandbox'
+    browser_options.prefs['safebrowsing.enabled'] = true
+
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  end
+
+  Capybara.default_driver = :rack_test
+  Capybara.javascript_driver = :selenium_chrome_headless_sandboxless
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -11,7 +11,13 @@ RSpec.configure do |_config|
     browser_options.args << '--no-sandbox'
     browser_options.prefs['safebrowsing.enabled'] = true
 
-    Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+    # Create the driver with the specified options
+    driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+
+    # Set the window size to a typical desktop resolution
+    driver.browser.manage.window.resize_to(1280, 1024)
+
+    driver
   end
 
   Capybara.default_driver = :rack_test


### PR DESCRIPTION
This PR takes the multiple initialization of Capybara drivers in several feature tests and puts it into a single support file.  This increases how DRY the code is and slightly improves efficiency as the drivers only need to be initialized once.

It also adds a default screen size for testing, to reduce confusion when testing responsive layouts.  I added this to the PR to make this PR able to be merged in any order with the pr's labeled "review anytime"