### PR TITLE
LIBTREATDB-74 Update user active checkbox to a slider

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -18,6 +18,9 @@ import 'bootstrap';
 // Import custom CSS
 import './stylesheets/application.scss';
 
+// Import custom JavaScript
+import './custom/account_active_toggle_switch.js';
+
 // Import all the images in the images file:
 function importAll(r) {
     r.keys().forEach(r);

--- a/app/javascript/custom/account_active_toggle_switch.js
+++ b/app/javascript/custom/account_active_toggle_switch.js
@@ -1,0 +1,23 @@
+document.addEventListener('turbolinks:load', function() {
+    const switchInput = document.getElementById('accountActiveSwitch');
+    const switchLabel = document.getElementById('accountActiveLabel');
+
+    function updateLabel() {
+        if (!switchInput || !switchLabel) return;
+
+        if (switchInput.checked) {
+            switchLabel.textContent = 'Account Active';
+        } else {
+            switchLabel.textContent = 'Account Inactive';
+        }
+    }
+
+    // Initial label update
+    updateLabel();
+
+    if (switchInput) {
+        switchInput.addEventListener('change', function() {
+            updateLabel();
+        });
+    }
+});

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -26,11 +26,10 @@
 		<%= form.collection_select(:role, User::ROLES, :to_s, lambda{|i| i.to_s.humanize}, {}, {:class=>'form-control'}) %>
   </div>
 
-  <div class="field form-check">
-		<%= form.check_box :account_active, class: 'form-check-input' %>
-    <%= form.label :account_active, class: 'form-check-label' %>
+  <div class="field form-check form-switch d-flex align-items-center mb-3">
+    <%= form.check_box :account_active, class: 'form-check-input', id: 'accountActiveSwitch' %>
+    <%= form.label :account_active, 'Account Active', class: 'form-check-label ms-2', id: 'accountActiveLabel', for: 'accountActiveSwitch' %>
   </div>
-
 
   <div class="actions">
     <%= form.submit class: 'btn btn-primary'%>

--- a/spec/features/account_active_slider.rb
+++ b/spec/features/account_active_slider.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Account Active Slider', type: :feature, js: true do
+  let(:admin_user) { create(:user, role: 'admin') }
+  let(:standard_user) { create(:user, role: 'standard', account_active: false) }
+  let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 2) }
+  let(:vocabulary) { create(:controlled_vocabulary) }
+
+  scenario 'user toggles the account active slider and label changes' do
+    log_in_user(admin_user)
+    visit edit_user_path(standard_user)
+
+    # Verify initial state
+    expect(find('#accountActiveSwitch')).not_to be_checked
+    expect(find('#accountActiveLabel')).to have_content('Account Inactive')
+
+    # Toggle the switch (simulate clicking the slider)
+    find('#accountActiveSwitch').set(true)
+
+    # Verify label update
+    expect(find('#accountActiveLabel')).to have_content('Account Active')
+
+    # Toggle back
+    find('#accountActiveSwitch').set(false)
+
+    # Verify label update again
+    expect(find('#accountActiveLabel')).to have_content('Account Inactive')
+  end
+
+  # Login
+  def log_in_user(user)
+    visit new_user_session_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: 'notapassword'
+    click_button 'Log in'
+    expect(page).to have_content('Signed in successfully')
+  end
+end

--- a/spec/features/account_active_slider.rb
+++ b/spec/features/account_active_slider.rb
@@ -2,32 +2,33 @@
 
 require 'rails_helper'
 
-RSpec.feature 'Account Active Slider', type: :feature, js: true do
+RSpec.describe 'Account Active Slider', type: :feature, js: true do
   let(:admin_user) { create(:user, role: 'admin') }
   let(:standard_user) { create(:user, role: 'standard', account_active: false) }
 
-  scenario 'user toggles the account active slider and label changes' do
-    log_in_user(admin_user)
-    visit edit_user_path(standard_user)
+  context 'when admin toggles the account active slider' do
+    before do
+      log_in_user(admin_user)
+      visit edit_user_path(standard_user)
+    end
 
-    # Verify initial state
-    expect(find('#accountActiveSwitch')).not_to be_checked
-    expect(find('#accountActiveLabel')).to have_content('Account Inactive')
+    it 'displays the correct initial state' do
+      expect(find('#accountActiveSwitch')).not_to be_checked
+      expect(find('#accountActiveLabel')).to have_content('Account Inactive')
+    end
 
-    # Toggle the switch (simulate clicking the slider)
-    find('#accountActiveSwitch').set(true)
+    it 'updates the label to Account Active when toggled' do
+      expect(find('#accountActiveLabel')).to have_content('Account Inactive')
 
-    # Verify label update
-    expect(find('#accountActiveLabel')).to have_content('Account Active')
+      find('#accountActiveSwitch').set(true)
+      expect(find('#accountActiveLabel')).to have_content('Account Active')
 
-    # Toggle back
-    find('#accountActiveSwitch').set(false)
-
-    # Verify label update again
-    expect(find('#accountActiveLabel')).to have_content('Account Inactive')
+      find('#accountActiveSwitch').set(false)
+      expect(find('#accountActiveLabel')).to have_content('Account Inactive')
+    end
   end
 
-  # Login
+  # Login helper
   def log_in_user(user)
     visit new_user_session_path
     fill_in 'Email', with: user.email

--- a/spec/features/account_active_slider.rb
+++ b/spec/features/account_active_slider.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.feature 'Account Active Slider', type: :feature, js: true do
   let(:admin_user) { create(:user, role: 'admin') }
   let(:standard_user) { create(:user, role: 'standard', account_active: false) }
-  let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 2) }
-  let(:vocabulary) { create(:controlled_vocabulary) }
 
   scenario 'user toggles the account active slider and label changes' do
     log_in_user(admin_user)

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :request do
+  let(:admin_user) { create(:user, role: :admin) }
+  let(:user) { create(:user, account_active: false) }
+
+  before do
+    sign_in admin_user # Sign in as an admin user
+  end
+
+  it 'allows admin to update account_active status' do
+    # Admin updates account_active to true
+    patch user_path(user), params: { user: { account_active: true } }
+    expect(user.reload.account_active).to be true
+
+    # Admin updates account_active to false
+    patch user_path(user), params: { user: { account_active: false } }
+    expect(user.reload.account_active).to be false
+  end
+end


### PR DESCRIPTION
https://ucdts.atlassian.net/browse/LIBTREATDB-74

This is a cosmetic upgrade for the admin user.  To mark a user as active or not, previously we had a checkbox.  Now, with the adoption of Bootstrap 5, we have the option of using a slider which is more intuitive for this case.

This PR changes the "Active" checkbox to a slider that will display either "Account Active" or "Account Inactive" depending on the state of the slider.

If the slider is not changing the Account Active/Inactive status, you probably need to run `yarn install` and `yarn build`.  Then, clear the cache and reload the page.