### PR TITLE
LIBTREATDB-75 Correct feature tests to use js: true

### DIFF
--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -25,10 +25,6 @@ RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   let(:user) { create(:user, role: 'read_only') }
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
 
-  # before do
-  #   page.driver.browser.manage.window.resize_to(1200, 800)
-  # end
-
   it 'allows User to login and show Conservation Records' do
     # Login
     visit new_user_session_path
@@ -72,10 +68,6 @@ RSpec.describe 'Standard User Tests', type: :feature, versioning: true, js: true
   let!(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
   let(:today_date) { Time.zone.today.strftime('%Y-%m-%d') }
-
-  # before do
-  #   page.driver.browser.manage.window.resize_to(1200, 800)
-  # end
 
   it 'allows User to login and show Conservation Records' do
     # Login
@@ -219,10 +211,6 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true, js: true do
   let(:vocabulary) { create(:controlled_vocabulary) }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
   let(:today_date) { Time.zone.today.strftime('%Y-%m-%d') }
-
-  # before do
-  #   page.driver.browser.manage.window.resize_to(1200, 800)
-  # end
 
   it 'allows User to login and show Conservation Records' do
     # Login

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -24,6 +24,11 @@ end
 RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   let(:user) { create(:user, role: 'read_only') }
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
+
+  # before do
+  #   page.driver.browser.manage.window.resize_to(1200, 800)
+  # end
+
   it 'allows User to login and show Conservation Records' do
     # Login
     visit new_user_session_path
@@ -62,10 +67,15 @@ RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   end
 end
 
-RSpec.describe 'Standard User Tests', type: :feature, versioning: true do
+RSpec.describe 'Standard User Tests', type: :feature, versioning: true, js: true do
   let(:user) { create(:user, role: 'standard') }
   let!(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
+  let(:today_date) { Time.zone.today.strftime('%Y-%m-%d') }
+
+  # before do
+  #   page.driver.browser.manage.window.resize_to(1200, 800)
+  # end
 
   it 'allows User to login and show Conservation Records' do
     # Login
@@ -101,6 +111,7 @@ RSpec.describe 'Standard User Tests', type: :feature, versioning: true do
     visit conservation_records_path
     click_on 'New Conservation Record'
     expect(page).to have_content('New Conservation Record')
+    fill_in 'Date received in preservation services', with: today_date
     select('PLCH', from: 'Department', match: :first)
     fill_in 'Title', with: conservation_record.title
     fill_in 'Author', with: conservation_record.author
@@ -167,9 +178,10 @@ RSpec.describe 'Standard User Tests', type: :feature, versioning: true do
     fill_in 'treatment_report_treatment_proposal_total_treatment_time', with: 10
     click_button('Save Treatment Report')
     expect(page).to have_content('Treatment Record updated successfully!')
-    click_on 'Condition'
-    expect(page).to have_select('treatment_report_treatment_proposal_housing_need_id', selected: 'Portfolio')
-    expect(page).to have_select('treatment_report_treatment_proposal_housing_provided_id', selected: 'Portfolio')
+    click_on 'Treatment Proposal'
+    expect(page).to have_content('Housing Need')
+    expect(page).to have_select('treatment_report_treatment_proposal_housing_need_id', selected: ['Portfolio'])
+    expect(page).to have_select('treatment_report_treatment_proposal_housing_provided_id', selected: ['Portfolio'])
 
     # Save Cost Return Information
     expect(page).to have_content('Cost and Return Information')
@@ -194,16 +206,23 @@ RSpec.describe 'Standard User Tests', type: :feature, versioning: true do
 
     # Delete conservation record
     visit conservation_records_path
-    find("a[id='delete_conservation_record_#{conservation_record.id}']").click
+    accept_confirm do
+      find("a[id='delete_conservation_record_#{conservation_record.id}']").click
+    end
     expect(page).to have_content('Conservation record was successfully destroyed.')
   end
 end
 
-RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
+RSpec.describe 'Admin User Tests', type: :feature, versioning: true, js: true do
   let(:user) { create(:user, role: 'admin') }
-  let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
+  let!(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms') }
   let(:vocabulary) { create(:controlled_vocabulary) }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
+  let(:today_date) { Time.zone.today.strftime('%Y-%m-%d') }
+
+  # before do
+  #   page.driver.browser.manage.window.resize_to(1200, 800)
+  # end
 
   it 'allows User to login and show Conservation Records' do
     # Login
@@ -286,6 +305,7 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     visit conservation_records_path
     click_on 'New Conservation Record'
     expect(page).to have_content('New Conservation Record')
+    fill_in 'Date received in preservation services', with: today_date
     select('PLCH', from: 'Department', match: :first)
     fill_in 'Title', with: conservation_record.title
     fill_in 'Author', with: conservation_record.author
@@ -319,7 +339,9 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_content('Mend paper performed by Haritha Vytla in 2 minutes. Other note: Some Other note for the in-house repair')
 
     # Delete In-house repair
-    find("a[id='delete_in_house_repair_record_1']").click
+    accept_confirm do
+      find("a[id='delete_in_house_repair_record_1']").click
+    end
     expect(page).not_to have_content('Mend paper performed by Haritha Vytla')
 
     # Create External Repair
@@ -332,7 +354,9 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_content('Wash performed by Amanda Buck. Other note: Some Other note for the external repair')
 
     # Delete external repair
-    find("a[id='delete_external_repair_record_1']").click
+    accept_confirm do
+      find("a[id='delete_external_repair_record_1']").click
+    end
     expect(page).not_to have_content('Wash performed by Amanda Buck')
 
     # Conservators and Technicians
@@ -383,19 +407,16 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_content('Item Detail')
     expect(page).to have_content(conservation_record.title)
 
-    # Download Conservation Worksheet
-    click_on 'Download Conservation Worksheet'
-    expect(page.status_code).to eq(200)
+    # Verify the Conservation Worksheet link and return to the original page
+    verify_download_link('Download Conservation Worksheet')
+    expect(page).to have_content(conservation_record.title)
 
-    # Download Treatment Report
-    visit conservation_record_path(conservation_record)
-    click_on 'Download Treatment Report'
-    expect(page.status_code).to eq(200)
+    # Verify the Treatment Report link and return to the original page
+    verify_download_link('Download Treatment Report')
+    expect(page).to have_content(conservation_record.title)
 
-    # Download Abbreviated Treatment Report
-    visit conservation_record_path(conservation_record)
-    first(:link, 'Download Abbreviated Treatment Report').click
-    expect(page.status_code).to eq(200)
+    # Verify the Abbreviated Treatment Report link and return to the original page
+    verify_download_link('Download Abbreviated Treatment Report')
 
     # Verify logged activity
     visit activity_index_path
@@ -415,7 +436,9 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
     expect(page).to have_content('Treatment Record updated successfully!')
     visit activity_index_path
     expect(page).to have_content('Haritha Vytla updated the treatment report')
-    first('tr').click_link('Details')
+    within first('tbody tr') do
+      click_link 'Details'
+    end
     expect(page).to have_content('Full leather tightjoint, tight back binding')
     expect(page).to have_content('Half leather tightjoint, tight back binding')
   end

--- a/spec/features/read_only_user_spec.rb
+++ b/spec/features/read_only_user_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 'ARB Library') }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
 
-  # before do
-  #   page.driver.browser.manage.window.resize_to(1200, 800)
-  # end
-
   it 'allows User to login and show Conservation Records' do
     # Login
 

--- a/spec/features/read_only_user_spec.rb
+++ b/spec/features/read_only_user_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'Read Only User Tests', type: :feature, js: true do
   let(:conservation_record) { create(:conservation_record, title: 'Farewell to Arms', department: 'ARB Library') }
   let!(:staff_code) { create(:staff_code, code: 'test', points: 10) }
 
+  # before do
+  #   page.driver.browser.manage.window.resize_to(1200, 800)
+  # end
+
   it 'allows User to login and show Conservation Records' do
     # Login
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,7 @@ end
 RSpec.configure do |config|
   config.include_context 'rake', type: :task
   config.include_context 'job', type: :job
+  config.include DownloadLinkHelper, type: :feature
 
   # Load all Capistrano tasks before running any tests
   config.before(:suite) do

--- a/spec/support/download_link_helper.rb
+++ b/spec/support/download_link_helper.rb
@@ -2,28 +2,41 @@
 
 module DownloadLinkHelper
   def verify_download_link(link_text)
-    # Ensure the link is present
-    expect(page).to have_link(link_text)
-
-    # Capture the current URL before clicking the link
+    # Capture the current URL before interacting with the link
     original_url = current_url
 
-    # Convert the link text to a corresponding path fragment
-    path_fragment = link_text.sub('Download ', '').downcase.gsub(' ', '_')
+    ensure_link_presence(link_text)
+    ensure_link_has_blank_target(link_text)
+    remove_blank_target_from_links
+    click_and_verify_link(link_text)
 
-    # Remove target="_blank" from all links so that they link open in the same tab
-    execute_script("document.querySelectorAll('a[target=\"_blank\"]').forEach(function(el) { el.removeAttribute('target'); });")
-
-    # Click the link, which now opens in the same tab
-    click_link link_text
-
-    # Build the expected URL pattern based on the modified path fragment
-    expected_path_pattern = %r{/conservation_records/\d+/#{path_fragment}}
-
-    # Verify the URL matches the expected path pattern
-    expect(current_path).to match(expected_path_pattern)
-
-    # Return to the original URL
+    # Return to the original URL after verification
     visit original_url
+  end
+
+  private
+
+  def ensure_link_presence(link_text)
+    expect(page).to have_link(link_text)
+  end
+
+  def ensure_link_has_blank_target(link_text)
+    link = find_link(link_text)
+    expect(link[:target]).to eq('_blank')
+  end
+
+  def remove_blank_target_from_links
+    execute_script("document.querySelectorAll('a[target=\"_blank\"]').forEach(function(el) { el.removeAttribute('target'); });")
+  end
+
+  def click_and_verify_link(link_text)
+    click_link link_text
+    verify_url_matches_pattern(link_text)
+  end
+
+  def verify_url_matches_pattern(link_text)
+    path_fragment = link_text.sub('Download ', '').downcase.gsub(' ', '_')
+    expected_path_pattern = %r{/conservation_records/\d+/#{path_fragment}}
+    expect(current_path).to match(expected_path_pattern)
   end
 end

--- a/spec/support/download_link_helper.rb
+++ b/spec/support/download_link_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DownloadLinkHelper
+  def verify_download_link(link_text)
+    # Ensure the link is present
+    expect(page).to have_link(link_text)
+
+    # Capture the current URL before clicking the link
+    original_url = current_url
+
+    # Convert the link text to a corresponding path fragment
+    path_fragment = link_text.sub('Download ', '').downcase.gsub(' ', '_')
+
+    # Remove target="_blank" from all links so that they link open in the same tab
+    execute_script("document.querySelectorAll('a[target=\"_blank\"]').forEach(function(el) { el.removeAttribute('target'); });")
+
+    # Click the link, which now opens in the same tab
+    click_link link_text
+
+    # Build the expected URL pattern based on the modified path fragment
+    expected_path_pattern = %r{/conservation_records/\d+/#{path_fragment}}
+
+    # Verify the URL matches the expected path pattern
+    expect(current_path).to match(expected_path_pattern)
+
+    # Return to the original URL
+    visit original_url
+  end
+end


### PR DESCRIPTION
Our end-to-end and user-specific feature tests should have js: true in their metadata but currently don’t.  This is causing some tests to pass when they shouldn’t.

This pr adds js: true to the feature tests and corrects failing tests.

It introduces a helper module for checking that the “Download” links function as expected.  The expected behavior for these links is that they open up a new tab with a PDF of the requested report.  Limitations of Capybara prevent us from reading these new pages.  Instead, we temporarily disable the target: _blank property and check that the page displayed has the appropriate URL before returning to the original page.