### PR TITLE
LIBTREATDB-99 admins should not be able to change email for sso

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,8 @@ module Admin
     end
 
     def update
-      if @user.update(user_params)
+      sanitized_params = user_params.except(:email)
+      if @user.update(sanitized_params)
         redirect_to admin_users_path, notice: 'Profile updated successfully.'
       else
         flash.now[:alert] = 'There was a problem editing the user. Please check the errors below.'

--- a/app/views/admin/users/_edit_form.html.erb
+++ b/app/views/admin/users/_edit_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field form-group">
     <%= form.label :email %>
-    <%= form.text_field :email, class: 'form-control' %>
+    <%= form.text_field :email, class: 'form-control', disabled: true %>
   </div>
 
   <div class="field form-group">

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true do
 
     expect(page).to have_content('Edit User')
     fill_in 'Display name', with: 'Haritha Vytla'
-    fill_in 'Email', with: 'vytlasa@uc.edu'
     select('Admin', from: 'Role')
     click_on 'Update User'
     expect(page).to have_content('Haritha Vytla')

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -257,7 +257,6 @@ RSpec.describe 'Admin User Tests', type: :feature, versioning: true, js: true do
 
     expect(page).to have_content('Edit User')
     fill_in 'Display name', with: 'Haritha Vytla'
-    fill_in 'Email', with: 'vytlasa@uc.edu'
     select('Admin', from: 'Role')
     click_on 'Update User'
     expect(page).to have_content('Haritha Vytla')


### PR DESCRIPTION
Link: https://ucdts.atlassian.net/browse/LIBTREATDB-99

This PR takes away the ability of admins to update or change a user's email once it is set.  If an admin makes an error in the user creation phase and needs to use a different email, they will need to create a new user.  It gray's out the email section in a form and ignores any `params[:email]` sent to #update.  The only things an admin can change are display name, role, and active_status.

![Screenshot 2024-11-25 at 1 10 02 PM](https://github.com/user-attachments/assets/d72952c7-397f-49f5-af3e-cf48c9ec805e)
