### PR TITLE
LIBTREATDB-102 Add configuration to run github workflow jira-pr-updater-action

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -1,0 +1,15 @@
+name: Update PR with Jira Issue
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  update-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR with Jira Issue
+        uses: uclibs/jira-pr-updater-action@v1
+        with:
+          jira-base-url: 'https://ucdts.atlassian.net'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jira Issue: [LIBTREATDB-102](https://ucdts.atlassian.net/browse/LIBTREATDB-102)

This PR adds a configuration file for Github so that it will automatically run the shared action jira-pr-updater-action when a PR is created or edited.